### PR TITLE
Add SulfideElementCollection class and LengthCondition

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -21,7 +21,8 @@
 		"withTextCaseInsensitive": true,
 		"exist": true,
 		"visible": true,
-		"cssClass": true
+		"cssClass": true,
+		"length": true
 	},
 	"rules": {
 		"array-callback-return": "error",
@@ -47,7 +48,7 @@
 		"newline-before-return": "off",
 		"newline-per-chained-call": "off",
 
-		
+
 		"no-alert": "error",
 		"no-array-constructor": "error",
 		"no-await-in-loop": "error",

--- a/modules/Conditions.js
+++ b/modules/Conditions.js
@@ -1,6 +1,6 @@
 const fs = require('fs');
 
-module.exports = (Sulfide, SulfideElement) => {
+module.exports = (Sulfide, SulfideElement, SulfideElementCollection) => {
 	/**
 	 * Base class for conditions.
 	 */
@@ -58,11 +58,18 @@ module.exports = (Sulfide, SulfideElement) => {
 		}
 	}
 
-	// Read the conditions from the condtions directory
-	const files = fs.readdirSync(__dirname + '/conditions');
+	// Read the conditions from the conditions directory
+	let files = fs.readdirSync(__dirname + '/conditions');
 	const factories = {};
 	files.forEach(file => {
 		const condition = require('./conditions/' + file)(Sulfide, SulfideElement, Condition); // eslint-disable-line global-require
+		factories[condition.factoryName] = condition.factory;
+	});
+
+	// Read the collection conditions from the collectionConditions directory
+	files = fs.readdirSync(__dirname + '/collectionConditions');
+	files.forEach(file => {
+		const condition = require('./collectionConditions/' + file)(Sulfide, SulfideElementCollection, Condition); // eslint-disable-line global-require
 		factories[condition.factoryName] = condition.factory;
 	});
 

--- a/modules/Sulfide.js
+++ b/modules/Sulfide.js
@@ -3,7 +3,8 @@ const puppeteer = require('puppeteer');
 require('./String');
 
 const SulfideElement = require('./SulfideElement')(Sulfide);
-const Conditions = require('./Conditions')(Sulfide, SulfideElement);
+const SulfideElementCollection = require('./SulfideElementCollection')(Sulfide, SulfideElement);
+const Conditions = require('./Conditions')(Sulfide, SulfideElement, SulfideElementCollection);
 const Selectors = require('./Selectors')(Sulfide, SulfideElement);
 
 /**
@@ -29,6 +30,16 @@ function Sulfide(selector) {
 	}
 
 	return new SulfideElement(selector);
+}
+
+function $$(selector) {
+	if ( selector instanceof SulfideElement ) {
+		const collection = new SulfideElementCollection();
+		collection.selectors = [].concat(selector.selectors);
+		return collection;
+	}
+
+	return new SulfideElementCollection(selector);
 }
 
 /* eslint-disable no-magic-numbers */
@@ -149,6 +160,7 @@ for ( const selector in Selectors ) {
 // Add everything to the global namespace for easy usage
 if ( !Sulfide.config.noGlobals ) {
 	global.$ = Sulfide;
+	global.$$ = $$;
 
 	// Add the selectors
 	for ( const selector in Selectors ) {

--- a/modules/SulfideElementCollection.js
+++ b/modules/SulfideElementCollection.js
@@ -1,0 +1,50 @@
+module.exports = (Sulfide, SulfideElement) => (
+	/**
+	 * A SulfideElementCollection represents a list of DOM Elements specified by a selector.
+	 * It can be used to run checks on DOM Elements, e.g. if there exist a certain number of
+	 * those elements.
+	 */
+	class SulfideElementCollection extends SulfideElement {
+		/**
+		 * Returns a an array of DOM Elements based on the selectors of this
+		 * collection
+		 * @return {Promise} Resolves to an array with DOM Elements
+		 */
+		async getDomElements() {
+			// Start with the page as base to find the elements
+			let domElement = await Sulfide.getPage();
+			const selectors = [...this.selectors];
+
+			if ( selectors.length === 0 ) {
+				// An collection without selectors is empty
+				return [];
+			}
+
+			try {
+				while ( selectors.length ) {
+					const selector = selectors.shift();
+					if ( selector.isXPath() ) {
+						if ( selectors.length === 1 ) {
+							throw new Error('Collection selector cannot be an xpath');
+						}
+						domElement = await domElement.$x(selector); // eslint-disable-line no-await-in-loop
+						domElement = domElement.length > 0 ? domElement[0] : null;
+					} else if ( selectors.length === 0 ) {
+						// Last selector should be for a collection
+						domElement = await domElement.$$(selector); // eslint-disable-line no-await-in-loop
+					} else {
+						domElement = await domElement.$(selector); // eslint-disable-line no-await-in-loop
+					}
+
+					if ( !domElement ) {
+						return null;
+					}
+				}
+			} catch (err) {
+				//console.log('Error:', err)
+			}
+
+			return domElement;
+		}
+	}
+);

--- a/modules/collectionConditions/LengthCondition.js
+++ b/modules/collectionConditions/LengthCondition.js
@@ -1,0 +1,58 @@
+module.exports = (Sulfide, SulfideElementCollection, Condition) => {
+	/**
+	 * Condition to test if an element collection has a certain number
+	 * of elements on the page.
+	 */
+	class LengthCondition extends Condition {
+		constructor(length, timeout) {
+			super(timeout);
+			this.length = Number(length);
+			this.actualLength = 0;
+		}
+
+		/**
+		 * Returns the message that will be passed to Jasmine when the condition is not met.
+		 * @param  {SulfideElement} element The element for which the condition will be tested
+		 * @return {String} The failure message for this condition
+		 */
+		getFailureMessage(element, negate) {
+			if ( negate ) {
+				return 'Number of found elements is equal to ' + this.length;
+			}
+
+			return 'Number of found elements is not equal to ' + this.length + ' but to ' + this.actualLength;
+		}
+
+		/**
+		 * Tests if the given SulfideElementCollection has the given length
+		 * @param  {SulfideElementCollection} elements The elements for which the condition will be tested
+		 * @return {Promise} Resolves with true when the condition is met before the timout, false otherwise
+		 */
+		async test(collection) {
+			if ( !(collection instanceof SulfideElementCollection) ) {
+				throw new Error('length(number) can only be used on a collection of elements');
+			}
+
+			const domElements = await collection.getDomElements();
+			this.actualLength = domElements.length;
+			return domElements.length === this.length;
+		}
+	}
+
+	// Factory function to create a LengthCondition
+	const length = (count, timeout) => new LengthCondition(count, timeout);
+
+	// Add shortcut functions to the SulfideElementCollection class
+	SulfideElementCollection.prototype.shouldHaveLength = async function shouldHaveLength(count, timeout) {
+		return this.should(length(count, timeout));
+	};
+	SulfideElementCollection.prototype.shouldNotHaveLength = async function shouldNotHaveLength(count, timeout) {
+		return this.shouldNot(length(count, timeout));
+	};
+
+	return {
+		class: LengthCondition,
+		factory: length,
+		factoryName: 'length',
+	};
+};

--- a/tests/specs/conditions/testLengthCondition.js
+++ b/tests/specs/conditions/testLengthCondition.js
@@ -1,0 +1,21 @@
+describe('LengthCondition', () => {
+	it('tests if a collection of elements has a certain number of elements', async () => {
+		await $.open('https://dekolos.github.io/sulfide/tests/todo/todo.html');
+		await $$('li').shouldHave(length(6)); // eslint-disable-line no-magic-numbers
+	});
+
+	it('tests if a collection of elements has a certain number of elements with the shortcut method', async () => {
+		await $.open('https://dekolos.github.io/sulfide/tests/todo/todo.html');
+		await $$('li').shouldHaveLength(6); // eslint-disable-line no-magic-numbers
+	});
+
+	it('tests if a collection of elements does not have a certain number of elements', async () => {
+		await $.open('https://dekolos.github.io/sulfide/tests/todo/todo.html');
+		await $$('li').shouldNotHave(length(10)); // eslint-disable-line no-magic-numbers
+	});
+
+	it('tests if a collection of elements does not have a certain number of elements with the shortcut method', async () => {
+		await $.open('https://dekolos.github.io/sulfide/tests/todo/todo.html');
+		await $$('li').shouldNotHaveLength(10); // eslint-disable-line no-magic-numbers
+	});
+});


### PR DESCRIPTION
The SulfideElementCollection represents a list of elements specified by
a selector (not an xpath!). The factory method $$ has been added to
Sulfide and the global namespace.

The LengthCondition can be used to test if an element list represented by
a SulfideElementCondition consists of a certain number of elements.

Example: $$('div').shouldHave(length(10))