### PR TITLE
Add support for NWJS apps

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -133,7 +133,6 @@
 		"no-trailing-spaces": ["error", { "skipBlankLines": false }],
 		"no-undef-init": "error",
 		"no-undefined": "error",
-		"no-underscore-dangle": "error",
 		"no-unexpected-multiline": "error",
 		"no-unmodified-loop-condition": "error",
 		"no-unneeded-ternary": ["error", {"defaultAssignment": false}],

--- a/tests/specs/helpers/beforeafter.js
+++ b/tests/specs/helpers/beforeafter.js
@@ -2,5 +2,5 @@
 global.beforeAll(() => {
 	// Increase the timeout of Jasmine to 20 seconds
 	// This way Chromium has more than 5 seconds to start up for the first test
-	jasmine.DEFAULT_TIMEOUT_INTERVAL = 20000; // 20 seconds
+	jasmine.DEFAULT_TIMEOUT_INTERVAL = 20000; // eslint-disable-line no-magic-numbers
 });


### PR DESCRIPTION
Adding an option to specify running an NWJS app.
Overrides the Target.page() function of puppeteer when running an NWJS
app to be able to get the page handle from a target.
'targetchanged' listener is added to $.open method when runing an NWJS
app to get the page handle.

TODO: sulfide should be able to handle multiple pages.