### PR TITLE
Add the posibility to add Chromium arguments

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -43,7 +43,7 @@
 		"guard-for-in": "error",
 		"indent": ["error", "tab", {"SwitchCase": 1}],
 		"max-lines": ["warn", {"max": 300, "skipBlankLines": true, "skipComments": true}],
-		"max-nested-callbacks": ["warn", {"max":2}],
+		"max-nested-callbacks": ["warn", {"max":4}],
 		"max-statements-per-line": ["error", {"max": 1}],
 		"multiline-ternary": ["warn", "never"],
 		"new-cap": "error",

--- a/tests/specs/testSulfide.js
+++ b/tests/specs/testSulfide.js
@@ -1,4 +1,93 @@
 describe('Sulfide', () => {
+	it('can be configured to run headless or with head', () => {
+		$.configure({
+			headless: false,
+		});
+		let options = $.getBrowserLaunchOptions();
+		expect(options.headless).toBe(false);
+
+		$.configure({
+			headless: true,
+		});
+		options = $.getBrowserLaunchOptions();
+		expect(options.headless).toBe(true);
+	});
+
+	it('can be configured to ignore https errors or not to ignore them', () => {
+		$.configure({
+			ignoreHTTPSErrors: true,
+		});
+		let options = $.getBrowserLaunchOptions();
+		expect(options.ignoreHTTPSErrors).toBe(true);
+
+		$.configure({
+			ignoreHTTPSErrors: false,
+		});
+		options = $.getBrowserLaunchOptions();
+		expect(options.ignoreHTTPSErrors).toBe(false);
+	});
+
+	it('can be configured to start with dev tools open or closed', () => {
+		$.configure({
+			devtools: true,
+		});
+		let options = $.getBrowserLaunchOptions();
+		expect(options.devtools).toBe(true);
+
+		$.configure({
+			devtools: false,
+		});
+		options = $.getBrowserLaunchOptions();
+		expect(options.devtools).toBe(false);
+	});
+
+	it('can be configured to add chrome arguments', () => {
+		$.configure({
+			chromeArgs: [
+				'--parent-profile /path/to/my/profile',
+			],
+		});
+		const options = $.getBrowserLaunchOptions();
+		expect(options.args.indexOf('--parent-profile /path/to/my/profile')).toBeGreaterThan(-1);
+	});
+
+	it('throws an error when chrome arguments that are not an array are added to the configuration', () => {
+		expect(() => {
+			$.configure({
+				chromeArgs: '--parent-profile /path/to/my/profile',
+			});
+		}).toThrow();
+	});
+
+	it('cannot explicitly set some chrome arguments', async () => {
+		const options = $.configure({
+			width: 500, // eslint-disable-line no-magic-numbers
+			height: 400, // eslint-disable-line no-magic-numbers
+			disableInfoBars: false,
+			chromeArgs: [
+				'--window-size=100,200',
+				'--app=http://somedomain/somepath',
+				'--disable-infobars',
+			],
+		});
+		let filteredArgs = options.chromeArgs.filter(o => o.indexOf('--window-size=') === 0);
+		expect(filteredArgs.length).toBe(0, '--window-size incorrectly added to chromium arguments');
+
+		filteredArgs = options.chromeArgs.filter(o => o.indexOf('--app=') === 0);
+		expect(filteredArgs.length).toBe(0, '--app=[URL] incorrectly added to chromium arguments');
+
+		filteredArgs = options.chromeArgs.filter(o => o.indexOf('--disable-infobars') === 0);
+		expect(filteredArgs.length).toBe(0, '--disable-infobars incorrectly added to chromium arguments');
+
+		// Set the defaults again for the other tests
+		$.configure({
+			width: 800, // eslint-disable-line no-magic-numbers
+			height: 600, // eslint-disable-line no-magic-numbers
+			disableInfobars: false,
+			chromeArgs: [],
+		});
+	});
+
 	it('closes the browser', async () => {
 		await $.open('https://www.example.com');
 		await $.close();


### PR DESCRIPTION
Sulfide can now be configured with Chromium arguments.
They can be added as array of strings in the property chromeArgs:

$.configure({
  chromeArgs: [
    '--bla',
    '--henk',
  ]
};