### PR TITLE
Import Target from the correct file to override it

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,5071 @@
+{
+	"name": "sulfide",
+	"version": "0.2.1",
+	"lockfileVersion": 1,
+	"requires": true,
+	"dependencies": {
+		"acorn": {
+			"version": "5.5.3",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.3.tgz",
+			"integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ==",
+			"dev": true
+		},
+		"acorn-jsx": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+			"integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
+			"dev": true,
+			"requires": {
+				"acorn": "3.3.0"
+			},
+			"dependencies": {
+				"acorn": {
+					"version": "3.3.0",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+					"integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
+					"dev": true
+				}
+			}
+		},
+		"agent-base": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.0.tgz",
+			"integrity": "sha512-c+R/U5X+2zz2+UCrCFv6odQzJdoqI+YecuhnAJLa1zYaMc13zPfwMwZrr91Pd1DYNo/yPRbiM4WVf9whgwFsIg==",
+			"requires": {
+				"es6-promisify": "5.0.0"
+			}
+		},
+		"ajv": {
+			"version": "5.5.2",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+			"integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+			"dev": true,
+			"requires": {
+				"co": "4.6.0",
+				"fast-deep-equal": "1.1.0",
+				"fast-json-stable-stringify": "2.0.0",
+				"json-schema-traverse": "0.3.1"
+			}
+		},
+		"ajv-keywords": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
+			"integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=",
+			"dev": true
+		},
+		"align-text": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+			"integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+			"dev": true,
+			"requires": {
+				"kind-of": "3.2.2",
+				"longest": "1.0.1",
+				"repeat-string": "1.6.1"
+			}
+		},
+		"amdefine": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+			"integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+			"dev": true
+		},
+		"ansi-align": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
+			"integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
+			"dev": true,
+			"requires": {
+				"string-width": "2.1.1"
+			}
+		},
+		"ansi-escapes": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
+			"integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
+			"dev": true
+		},
+		"ansi-regex": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+			"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+			"dev": true
+		},
+		"ansi-styles": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+			"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+			"dev": true
+		},
+		"argparse": {
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+			"dev": true,
+			"requires": {
+				"sprintf-js": "1.0.3"
+			}
+		},
+		"array-union": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+			"integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+			"dev": true,
+			"requires": {
+				"array-uniq": "1.0.3"
+			}
+		},
+		"array-uniq": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+			"integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+			"dev": true
+		},
+		"arrify": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+			"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+			"dev": true
+		},
+		"asn1": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+			"integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
+			"dev": true
+		},
+		"assert-plus": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+			"dev": true
+		},
+		"async": {
+			"version": "1.5.2",
+			"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+			"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+			"dev": true
+		},
+		"async-limiter": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
+			"integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
+		},
+		"asynckit": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+			"dev": true
+		},
+		"aws-sign2": {
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+			"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+			"dev": true
+		},
+		"aws4": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+			"integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
+			"dev": true
+		},
+		"babel-code-frame": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+			"integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+			"dev": true,
+			"requires": {
+				"chalk": "1.1.3",
+				"esutils": "2.0.2",
+				"js-tokens": "3.0.2"
+			}
+		},
+		"balanced-match": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+		},
+		"bcrypt-pbkdf": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+			"integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"tweetnacl": "0.14.5"
+			}
+		},
+		"boom": {
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
+			"integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
+			"dev": true,
+			"requires": {
+				"hoek": "4.2.1"
+			}
+		},
+		"boxen": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/boxen/-/boxen-1.3.0.tgz",
+			"integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
+			"dev": true,
+			"requires": {
+				"ansi-align": "2.0.0",
+				"camelcase": "4.1.0",
+				"chalk": "2.3.2",
+				"cli-boxes": "1.0.0",
+				"string-width": "2.1.1",
+				"term-size": "1.2.0",
+				"widest-line": "2.0.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
+					"requires": {
+						"color-convert": "1.9.1"
+					}
+				},
+				"camelcase": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+					"dev": true
+				},
+				"chalk": {
+					"version": "2.3.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
+					"integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "3.2.1",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.3.0"
+					}
+				},
+				"supports-color": {
+					"version": "5.3.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
+					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+					"dev": true,
+					"requires": {
+						"has-flag": "3.0.0"
+					}
+				}
+			}
+		},
+		"brace-expansion": {
+			"version": "1.1.11",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"requires": {
+				"balanced-match": "1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"caller-path": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
+			"integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
+			"dev": true,
+			"requires": {
+				"callsites": "0.2.0"
+			}
+		},
+		"callsites": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
+			"integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
+			"dev": true
+		},
+		"camelcase": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+			"integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+			"dev": true,
+			"optional": true
+		},
+		"capture-stack-trace": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
+			"integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0=",
+			"dev": true
+		},
+		"caseless": {
+			"version": "0.12.0",
+			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+			"dev": true
+		},
+		"center-align": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+			"integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"align-text": "0.1.4",
+				"lazy-cache": "1.0.4"
+			}
+		},
+		"chalk": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+			"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+			"dev": true,
+			"requires": {
+				"ansi-styles": "2.2.1",
+				"escape-string-regexp": "1.0.5",
+				"has-ansi": "2.0.0",
+				"strip-ansi": "3.0.1",
+				"supports-color": "2.0.0"
+			}
+		},
+		"chardet": {
+			"version": "0.4.2",
+			"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
+			"integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
+			"dev": true
+		},
+		"circular-json": {
+			"version": "0.3.3",
+			"resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
+			"integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
+			"dev": true
+		},
+		"cli-boxes": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
+			"integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM=",
+			"dev": true
+		},
+		"cli-cursor": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+			"integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+			"dev": true,
+			"requires": {
+				"restore-cursor": "2.0.0"
+			}
+		},
+		"cli-width": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+			"integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
+			"dev": true
+		},
+		"cliui": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+			"integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"center-align": "0.1.3",
+				"right-align": "0.1.3",
+				"wordwrap": "0.0.2"
+			},
+			"dependencies": {
+				"wordwrap": {
+					"version": "0.0.2",
+					"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+					"integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+					"dev": true,
+					"optional": true
+				}
+			}
+		},
+		"co": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+			"dev": true
+		},
+		"color-convert": {
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
+			"integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+			"dev": true,
+			"requires": {
+				"color-name": "1.1.3"
+			}
+		},
+		"color-name": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+			"dev": true
+		},
+		"combined-stream": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+			"integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+			"dev": true,
+			"requires": {
+				"delayed-stream": "1.0.0"
+			}
+		},
+		"commander": {
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+			"integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+			"dev": true,
+			"requires": {
+				"graceful-readlink": "1.0.1"
+			}
+		},
+		"concat-map": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+		},
+		"concat-stream": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
+			"integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
+			"requires": {
+				"inherits": "2.0.3",
+				"readable-stream": "2.3.5",
+				"typedarray": "0.0.6"
+			}
+		},
+		"configstore": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.2.tgz",
+			"integrity": "sha512-vtv5HtGjcYUgFrXc6Kx747B83MRRVS5R1VTEQoXvuP+kMI+if6uywV0nDGoiydJRy4yk7h9od5Og0kxx4zUXmw==",
+			"dev": true,
+			"requires": {
+				"dot-prop": "4.2.0",
+				"graceful-fs": "4.1.11",
+				"make-dir": "1.2.0",
+				"unique-string": "1.0.0",
+				"write-file-atomic": "2.3.0",
+				"xdg-basedir": "3.0.0"
+			}
+		},
+		"core-util-is": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+		},
+		"coveralls": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.0.0.tgz",
+			"integrity": "sha512-ZppXR9y5PraUOrf/DzHJY6gzNUhXYE3b9D43xEXs4QYZ7/Oe0Gy0CS+IPKWFfvQFXB3RG9QduaQUFehzSpGAFw==",
+			"dev": true,
+			"requires": {
+				"js-yaml": "3.11.0",
+				"lcov-parse": "0.0.10",
+				"log-driver": "1.2.7",
+				"minimist": "1.2.0",
+				"request": "2.85.0"
+			},
+			"dependencies": {
+				"minimist": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+					"dev": true
+				}
+			}
+		},
+		"create-error-class": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
+			"integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
+			"dev": true,
+			"requires": {
+				"capture-stack-trace": "1.0.0"
+			}
+		},
+		"cross-spawn": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+			"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+			"dev": true,
+			"requires": {
+				"lru-cache": "4.1.2",
+				"shebang-command": "1.2.0",
+				"which": "1.3.0"
+			}
+		},
+		"cryptiles": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
+			"integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
+			"dev": true,
+			"requires": {
+				"boom": "5.2.0"
+			},
+			"dependencies": {
+				"boom": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
+					"integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
+					"dev": true,
+					"requires": {
+						"hoek": "4.2.1"
+					}
+				}
+			}
+		},
+		"crypto-random-string": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
+			"integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
+			"dev": true
+		},
+		"dashdash": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+			"dev": true,
+			"requires": {
+				"assert-plus": "1.0.0"
+			}
+		},
+		"debug": {
+			"version": "2.6.9",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+			"requires": {
+				"ms": "2.0.0"
+			}
+		},
+		"decamelize": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+			"dev": true,
+			"optional": true
+		},
+		"deep-extend": {
+			"version": "0.4.2",
+			"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
+			"integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
+			"dev": true
+		},
+		"deep-is": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+			"dev": true
+		},
+		"del": {
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
+			"integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
+			"dev": true,
+			"requires": {
+				"globby": "5.0.0",
+				"is-path-cwd": "1.0.0",
+				"is-path-in-cwd": "1.0.1",
+				"object-assign": "4.1.1",
+				"pify": "2.3.0",
+				"pinkie-promise": "2.0.1",
+				"rimraf": "2.6.2"
+			},
+			"dependencies": {
+				"globby": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
+					"integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
+					"dev": true,
+					"requires": {
+						"array-union": "1.0.2",
+						"arrify": "1.0.1",
+						"glob": "7.1.2",
+						"object-assign": "4.1.1",
+						"pify": "2.3.0",
+						"pinkie-promise": "2.0.1"
+					}
+				}
+			}
+		},
+		"delayed-stream": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+			"dev": true
+		},
+		"doctrine": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+			"integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+			"dev": true,
+			"requires": {
+				"esutils": "2.0.2"
+			}
+		},
+		"dot-prop": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
+			"integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
+			"dev": true,
+			"requires": {
+				"is-obj": "1.0.1"
+			}
+		},
+		"dox": {
+			"version": "0.9.0",
+			"resolved": "https://registry.npmjs.org/dox/-/dox-0.9.0.tgz",
+			"integrity": "sha1-vpewhcufSgt+gINdVH53uGh9Cgw=",
+			"dev": true,
+			"requires": {
+				"commander": "2.9.0",
+				"jsdoctypeparser": "1.2.0",
+				"markdown-it": "7.0.1"
+			}
+		},
+		"doxdox": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/doxdox/-/doxdox-2.0.3.tgz",
+			"integrity": "sha1-Wf2qwAZFuSobWxOQ1vApTTzx18c=",
+			"dev": true,
+			"requires": {
+				"chalk": "1.1.3",
+				"doxdox-parser-dox": "1.1.3",
+				"doxdox-plugin-bootstrap": "1.1.8",
+				"doxdox-plugin-handlebars": "1.1.6",
+				"doxdox-plugin-markdown": "1.1.4",
+				"globby": "6.1.0",
+				"parse-cmd-args": "2.0.0",
+				"update-notifier": "2.1.0"
+			}
+		},
+		"doxdox-parser-dox": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/doxdox-parser-dox/-/doxdox-parser-dox-1.1.3.tgz",
+			"integrity": "sha512-6fzVViLTmVI715aAJIf5S8eqpMZPgpNa/o5W34qsbS2ALtZ4ERH7vjofisHtVd/Xqs3UHGtj4eKbOzT1CopcZg==",
+			"dev": true,
+			"requires": {
+				"dox": "0.9.0"
+			}
+		},
+		"doxdox-plugin-bootstrap": {
+			"version": "1.1.8",
+			"resolved": "https://registry.npmjs.org/doxdox-plugin-bootstrap/-/doxdox-plugin-bootstrap-1.1.8.tgz",
+			"integrity": "sha512-Lu/1Phqc9a05wZBn9Tj5kID4O28tBMDiFDy/nCV17qKXuzxJeWovs95s18STQxGls8se/+f3h7woDjwtc3IB+Q==",
+			"dev": true,
+			"requires": {
+				"handlebars": "4.0.10",
+				"highlight.js": "9.12.0",
+				"markdown-it": "8.3.2"
+			},
+			"dependencies": {
+				"markdown-it": {
+					"version": "8.3.2",
+					"resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-8.3.2.tgz",
+					"integrity": "sha512-4J92IhJq1kGoyXddwzzfjr9cEKGexBfFsZooKYMhMLLlWa4+dlSPDUUP7y+xQOCebIj61aLmKlowg//YcdPP1w==",
+					"dev": true,
+					"requires": {
+						"argparse": "1.0.10",
+						"entities": "1.1.1",
+						"linkify-it": "2.0.3",
+						"mdurl": "1.0.1",
+						"uc.micro": "1.0.5"
+					}
+				}
+			}
+		},
+		"doxdox-plugin-handlebars": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/doxdox-plugin-handlebars/-/doxdox-plugin-handlebars-1.1.6.tgz",
+			"integrity": "sha512-xJsfj5jIq3sEsvOkEXyywjrFaiOT8aoixAdN4zYr6aSEd2C5FIqzOph1AYM1RRKQktK/zl2jw1ORcg5Fjxsydg==",
+			"dev": true,
+			"requires": {
+				"handlebars": "4.0.10",
+				"highlight.js": "9.12.0",
+				"markdown-it": "8.3.2"
+			},
+			"dependencies": {
+				"markdown-it": {
+					"version": "8.3.2",
+					"resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-8.3.2.tgz",
+					"integrity": "sha512-4J92IhJq1kGoyXddwzzfjr9cEKGexBfFsZooKYMhMLLlWa4+dlSPDUUP7y+xQOCebIj61aLmKlowg//YcdPP1w==",
+					"dev": true,
+					"requires": {
+						"argparse": "1.0.10",
+						"entities": "1.1.1",
+						"linkify-it": "2.0.3",
+						"mdurl": "1.0.1",
+						"uc.micro": "1.0.5"
+					}
+				}
+			}
+		},
+		"doxdox-plugin-markdown": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/doxdox-plugin-markdown/-/doxdox-plugin-markdown-1.1.4.tgz",
+			"integrity": "sha512-VJeZjWAZlcFFa0WIM+eSZKmDvfFP0tN5RUm8nS5uoDgzkMB+UhPCTnNI8VINUoyD2mz1MHJk6fVMFwbxZL5JeA==",
+			"dev": true,
+			"requires": {
+				"handlebars": "4.0.10"
+			}
+		},
+		"duplexer3": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
+			"integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
+			"dev": true
+		},
+		"ecc-jsbn": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+			"integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"jsbn": "0.1.1"
+			}
+		},
+		"entities": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
+			"integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA=",
+			"dev": true
+		},
+		"es6-promise": {
+			"version": "4.2.4",
+			"resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.4.tgz",
+			"integrity": "sha512-/NdNZVJg+uZgtm9eS3O6lrOLYmQag2DjdEXuPaHlZ6RuVqgqaVZfgYCepEIKsLqwdQArOPtC3XzRLqGGfT8KQQ=="
+		},
+		"es6-promisify": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+			"integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+			"requires": {
+				"es6-promise": "4.2.4"
+			}
+		},
+		"escape-string-regexp": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+			"dev": true
+		},
+		"eslint": {
+			"version": "4.19.1",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-4.19.1.tgz",
+			"integrity": "sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==",
+			"dev": true,
+			"requires": {
+				"ajv": "5.5.2",
+				"babel-code-frame": "6.26.0",
+				"chalk": "2.3.2",
+				"concat-stream": "1.6.0",
+				"cross-spawn": "5.1.0",
+				"debug": "3.1.0",
+				"doctrine": "2.1.0",
+				"eslint-scope": "3.7.1",
+				"eslint-visitor-keys": "1.0.0",
+				"espree": "3.5.4",
+				"esquery": "1.0.1",
+				"esutils": "2.0.2",
+				"file-entry-cache": "2.0.0",
+				"functional-red-black-tree": "1.0.1",
+				"glob": "7.1.2",
+				"globals": "11.4.0",
+				"ignore": "3.3.7",
+				"imurmurhash": "0.1.4",
+				"inquirer": "3.3.0",
+				"is-resolvable": "1.1.0",
+				"js-yaml": "3.11.0",
+				"json-stable-stringify-without-jsonify": "1.0.1",
+				"levn": "0.3.0",
+				"lodash": "4.17.5",
+				"minimatch": "3.0.4",
+				"mkdirp": "0.5.1",
+				"natural-compare": "1.4.0",
+				"optionator": "0.8.2",
+				"path-is-inside": "1.0.2",
+				"pluralize": "7.0.0",
+				"progress": "2.0.0",
+				"regexpp": "1.1.0",
+				"require-uncached": "1.0.3",
+				"semver": "5.5.0",
+				"strip-ansi": "4.0.0",
+				"strip-json-comments": "2.0.1",
+				"table": "4.0.2",
+				"text-table": "0.2.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"dev": true
+				},
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
+					"requires": {
+						"color-convert": "1.9.1"
+					}
+				},
+				"chalk": {
+					"version": "2.3.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
+					"integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "3.2.1",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.3.0"
+					}
+				},
+				"debug": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"dev": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"lodash": {
+					"version": "4.17.5",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
+					"integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==",
+					"dev": true
+				},
+				"mkdirp": {
+					"version": "0.5.1",
+					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+					"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+					"dev": true,
+					"requires": {
+						"minimist": "0.0.8"
+					}
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "3.0.0"
+					}
+				},
+				"supports-color": {
+					"version": "5.3.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
+					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+					"dev": true,
+					"requires": {
+						"has-flag": "3.0.0"
+					}
+				}
+			}
+		},
+		"eslint-scope": {
+			"version": "3.7.1",
+			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
+			"integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
+			"dev": true,
+			"requires": {
+				"esrecurse": "4.2.1",
+				"estraverse": "4.2.0"
+			}
+		},
+		"eslint-visitor-keys": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
+			"integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
+			"dev": true
+		},
+		"espree": {
+			"version": "3.5.4",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
+			"integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
+			"dev": true,
+			"requires": {
+				"acorn": "5.5.3",
+				"acorn-jsx": "3.0.1"
+			}
+		},
+		"esprima": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+			"integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+			"dev": true
+		},
+		"esquery": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
+			"integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
+			"dev": true,
+			"requires": {
+				"estraverse": "4.2.0"
+			}
+		},
+		"esrecurse": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
+			"integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
+			"dev": true,
+			"requires": {
+				"estraverse": "4.2.0"
+			}
+		},
+		"estraverse": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+			"integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+			"dev": true
+		},
+		"esutils": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+			"dev": true
+		},
+		"execa": {
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+			"integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+			"dev": true,
+			"requires": {
+				"cross-spawn": "5.1.0",
+				"get-stream": "3.0.0",
+				"is-stream": "1.1.0",
+				"npm-run-path": "2.0.2",
+				"p-finally": "1.0.0",
+				"signal-exit": "3.0.2",
+				"strip-eof": "1.0.0"
+			}
+		},
+		"exit": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+			"integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw="
+		},
+		"extend": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+			"integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
+			"dev": true
+		},
+		"external-editor": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
+			"integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
+			"dev": true,
+			"requires": {
+				"chardet": "0.4.2",
+				"iconv-lite": "0.4.19",
+				"tmp": "0.0.33"
+			}
+		},
+		"extract-zip": {
+			"version": "1.6.6",
+			"resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.6.tgz",
+			"integrity": "sha1-EpDt6NINCHK0Kf0/NRyhKOxe+Fw=",
+			"requires": {
+				"concat-stream": "1.6.0",
+				"debug": "2.6.9",
+				"mkdirp": "0.5.0",
+				"yauzl": "2.4.1"
+			}
+		},
+		"extsprintf": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+			"dev": true
+		},
+		"fast-deep-equal": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+			"integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
+			"dev": true
+		},
+		"fast-json-stable-stringify": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+			"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+			"dev": true
+		},
+		"fast-levenshtein": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+			"dev": true
+		},
+		"fd-slicer": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
+			"integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
+			"requires": {
+				"pend": "1.2.0"
+			}
+		},
+		"figures": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+			"integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+			"dev": true,
+			"requires": {
+				"escape-string-regexp": "1.0.5"
+			}
+		},
+		"file-entry-cache": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
+			"integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
+			"dev": true,
+			"requires": {
+				"flat-cache": "1.3.0",
+				"object-assign": "4.1.1"
+			}
+		},
+		"flat-cache": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
+			"integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
+			"dev": true,
+			"requires": {
+				"circular-json": "0.3.3",
+				"del": "2.2.2",
+				"graceful-fs": "4.1.11",
+				"write": "0.2.1"
+			}
+		},
+		"forever-agent": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+			"dev": true
+		},
+		"form-data": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
+			"integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
+			"dev": true,
+			"requires": {
+				"asynckit": "0.4.0",
+				"combined-stream": "1.0.6",
+				"mime-types": "2.1.18"
+			}
+		},
+		"fs.realpath": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+		},
+		"functional-red-black-tree": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+			"integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+			"dev": true
+		},
+		"get-stream": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+			"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+			"dev": true
+		},
+		"getpass": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+			"dev": true,
+			"requires": {
+				"assert-plus": "1.0.0"
+			}
+		},
+		"glob": {
+			"version": "7.1.2",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+			"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+			"requires": {
+				"fs.realpath": "1.0.0",
+				"inflight": "1.0.6",
+				"inherits": "2.0.3",
+				"minimatch": "3.0.4",
+				"once": "1.4.0",
+				"path-is-absolute": "1.0.1"
+			}
+		},
+		"globals": {
+			"version": "11.4.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-11.4.0.tgz",
+			"integrity": "sha512-Dyzmifil8n/TmSqYDEXbm+C8yitzJQqQIlJQLNRMwa+BOUJpRC19pyVeN12JAjt61xonvXjtff+hJruTRXn5HA==",
+			"dev": true
+		},
+		"globby": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+			"integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
+			"dev": true,
+			"requires": {
+				"array-union": "1.0.2",
+				"glob": "7.1.2",
+				"object-assign": "4.1.1",
+				"pify": "2.3.0",
+				"pinkie-promise": "2.0.1"
+			}
+		},
+		"got": {
+			"version": "6.7.1",
+			"resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
+			"integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
+			"dev": true,
+			"requires": {
+				"create-error-class": "3.0.2",
+				"duplexer3": "0.1.4",
+				"get-stream": "3.0.0",
+				"is-redirect": "1.0.0",
+				"is-retry-allowed": "1.1.0",
+				"is-stream": "1.1.0",
+				"lowercase-keys": "1.0.1",
+				"safe-buffer": "5.1.1",
+				"timed-out": "4.0.1",
+				"unzip-response": "2.0.1",
+				"url-parse-lax": "1.0.0"
+			}
+		},
+		"graceful-fs": {
+			"version": "4.1.11",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+			"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+			"dev": true
+		},
+		"graceful-readlink": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+			"integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
+			"dev": true
+		},
+		"handlebars": {
+			"version": "4.0.10",
+			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.10.tgz",
+			"integrity": "sha1-PTDHGLCaPZbyPqTMH0A8TTup/08=",
+			"dev": true,
+			"requires": {
+				"async": "1.5.2",
+				"optimist": "0.6.1",
+				"source-map": "0.4.4",
+				"uglify-js": "2.8.29"
+			}
+		},
+		"har-schema": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+			"integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+			"dev": true
+		},
+		"har-validator": {
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+			"integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+			"dev": true,
+			"requires": {
+				"ajv": "5.5.2",
+				"har-schema": "2.0.0"
+			}
+		},
+		"has-ansi": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+			"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+			"dev": true,
+			"requires": {
+				"ansi-regex": "2.1.1"
+			}
+		},
+		"has-flag": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+			"dev": true
+		},
+		"hawk": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
+			"integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
+			"dev": true,
+			"requires": {
+				"boom": "4.3.1",
+				"cryptiles": "3.1.2",
+				"hoek": "4.2.1",
+				"sntp": "2.1.0"
+			}
+		},
+		"highlight.js": {
+			"version": "9.12.0",
+			"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.12.0.tgz",
+			"integrity": "sha1-5tnb5Xy+/mB1HwKvM2GVhwyQwB4=",
+			"dev": true
+		},
+		"hoek": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
+			"integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA==",
+			"dev": true
+		},
+		"http-signature": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+			"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+			"dev": true,
+			"requires": {
+				"assert-plus": "1.0.0",
+				"jsprim": "1.4.1",
+				"sshpk": "1.14.1"
+			}
+		},
+		"https-proxy-agent": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
+			"integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
+			"requires": {
+				"agent-base": "4.2.0",
+				"debug": "3.1.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				}
+			}
+		},
+		"iconv-lite": {
+			"version": "0.4.19",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+			"integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
+			"dev": true
+		},
+		"ignore": {
+			"version": "3.3.7",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz",
+			"integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA==",
+			"dev": true
+		},
+		"imurmurhash": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+			"dev": true
+		},
+		"inflight": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+			"requires": {
+				"once": "1.4.0",
+				"wrappy": "1.0.2"
+			}
+		},
+		"inherits": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+		},
+		"ini": {
+			"version": "1.3.5",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+			"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+			"dev": true
+		},
+		"inquirer": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
+			"integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
+			"dev": true,
+			"requires": {
+				"ansi-escapes": "3.1.0",
+				"chalk": "2.3.2",
+				"cli-cursor": "2.1.0",
+				"cli-width": "2.2.0",
+				"external-editor": "2.2.0",
+				"figures": "2.0.0",
+				"lodash": "4.17.5",
+				"mute-stream": "0.0.7",
+				"run-async": "2.3.0",
+				"rx-lite": "4.0.8",
+				"rx-lite-aggregates": "4.0.8",
+				"string-width": "2.1.1",
+				"strip-ansi": "4.0.0",
+				"through": "2.3.8"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"dev": true
+				},
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
+					"requires": {
+						"color-convert": "1.9.1"
+					}
+				},
+				"chalk": {
+					"version": "2.3.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
+					"integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "3.2.1",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.3.0"
+					}
+				},
+				"lodash": {
+					"version": "4.17.5",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
+					"integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==",
+					"dev": true
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "3.0.0"
+					}
+				},
+				"supports-color": {
+					"version": "5.3.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
+					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+					"dev": true,
+					"requires": {
+						"has-flag": "3.0.0"
+					}
+				}
+			}
+		},
+		"is-buffer": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+			"dev": true
+		},
+		"is-fullwidth-code-point": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+			"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+			"dev": true
+		},
+		"is-npm": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
+			"integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ=",
+			"dev": true
+		},
+		"is-obj": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+			"integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
+			"dev": true
+		},
+		"is-path-cwd": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
+			"integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
+			"dev": true
+		},
+		"is-path-in-cwd": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
+			"integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
+			"dev": true,
+			"requires": {
+				"is-path-inside": "1.0.1"
+			}
+		},
+		"is-path-inside": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
+			"integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
+			"dev": true,
+			"requires": {
+				"path-is-inside": "1.0.2"
+			}
+		},
+		"is-promise": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+			"integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+			"dev": true
+		},
+		"is-redirect": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
+			"integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
+			"dev": true
+		},
+		"is-resolvable": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
+			"integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
+			"dev": true
+		},
+		"is-retry-allowed": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
+			"integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=",
+			"dev": true
+		},
+		"is-stream": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+			"dev": true
+		},
+		"is-typedarray": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+			"dev": true
+		},
+		"isarray": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+		},
+		"isexe": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+			"dev": true
+		},
+		"isstream": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+			"dev": true
+		},
+		"jasmine": {
+			"version": "2.99.0",
+			"resolved": "https://registry.npmjs.org/jasmine/-/jasmine-2.99.0.tgz",
+			"integrity": "sha1-jKctEC5jm4Z8ZImFbg4YqceqQrc=",
+			"requires": {
+				"exit": "0.1.2",
+				"glob": "7.1.2",
+				"jasmine-core": "2.99.1"
+			}
+		},
+		"jasmine-console-reporter": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/jasmine-console-reporter/-/jasmine-console-reporter-2.0.1.tgz",
+			"integrity": "sha512-Q9pQ18NI+Oz9+kRmvcmM8oDTgiIoAESMRpO/DsyCOwIqktc7onsev6vKLmf3h+UP3AuX7xBB6xlREoV4jMOlzw==",
+			"dev": true,
+			"requires": {
+				"ansi-styles": "3.2.1",
+				"chalk": "2.3.2"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
+					"requires": {
+						"color-convert": "1.9.1"
+					}
+				},
+				"chalk": {
+					"version": "2.3.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
+					"integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "3.2.1",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.3.0"
+					}
+				},
+				"supports-color": {
+					"version": "5.3.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
+					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+					"dev": true,
+					"requires": {
+						"has-flag": "3.0.0"
+					}
+				}
+			}
+		},
+		"jasmine-core": {
+			"version": "2.99.1",
+			"resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.99.1.tgz",
+			"integrity": "sha1-5kAN8ea1bhMLYcS80JPap/boyhU="
+		},
+		"jasmine-should-fail": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/jasmine-should-fail/-/jasmine-should-fail-1.1.6.tgz",
+			"integrity": "sha512-KtChQagX446SvGLrvobed37v0gOoS5MFUiTePfqM8+VnlxweyC31axOxPiVhKIk4QtYWs/3VTSbmNLsOMqn1Xw==",
+			"dev": true
+		},
+		"js-tokens": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+			"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+			"dev": true
+		},
+		"js-yaml": {
+			"version": "3.11.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.11.0.tgz",
+			"integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
+			"dev": true,
+			"requires": {
+				"argparse": "1.0.10",
+				"esprima": "4.0.0"
+			}
+		},
+		"jsbn": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+			"dev": true,
+			"optional": true
+		},
+		"jsdoctypeparser": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/jsdoctypeparser/-/jsdoctypeparser-1.2.0.tgz",
+			"integrity": "sha1-597cFToRhJ/8UUEUSuhqfvDCU5I=",
+			"dev": true,
+			"requires": {
+				"lodash": "3.10.1"
+			}
+		},
+		"json-schema": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+			"dev": true
+		},
+		"json-schema-traverse": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+			"integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+			"dev": true
+		},
+		"json-stable-stringify-without-jsonify": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+			"integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+			"dev": true
+		},
+		"json-stringify-safe": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+			"dev": true
+		},
+		"jsprim": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+			"integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+			"dev": true,
+			"requires": {
+				"assert-plus": "1.0.0",
+				"extsprintf": "1.3.0",
+				"json-schema": "0.2.3",
+				"verror": "1.10.0"
+			}
+		},
+		"kind-of": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+			"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+			"dev": true,
+			"requires": {
+				"is-buffer": "1.1.6"
+			}
+		},
+		"latest-version": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",
+			"integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
+			"dev": true,
+			"requires": {
+				"package-json": "4.0.1"
+			}
+		},
+		"lazy-cache": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+			"integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
+			"dev": true,
+			"optional": true
+		},
+		"lazy-req": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/lazy-req/-/lazy-req-2.0.0.tgz",
+			"integrity": "sha1-yUUKNj7N2i5vDHATKtTzf48G8rQ=",
+			"dev": true
+		},
+		"lcov-parse": {
+			"version": "0.0.10",
+			"resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-0.0.10.tgz",
+			"integrity": "sha1-GwuP+ayceIklBYK3C3ExXZ2m2aM=",
+			"dev": true
+		},
+		"levn": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+			"integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+			"dev": true,
+			"requires": {
+				"prelude-ls": "1.1.2",
+				"type-check": "0.3.2"
+			}
+		},
+		"linkify-it": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.0.3.tgz",
+			"integrity": "sha1-2UpGSPmxwXnWT6lykSaL22zpQ08=",
+			"dev": true,
+			"requires": {
+				"uc.micro": "1.0.5"
+			}
+		},
+		"lodash": {
+			"version": "3.10.1",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+			"integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
+			"dev": true
+		},
+		"log-driver": {
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.7.tgz",
+			"integrity": "sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg==",
+			"dev": true
+		},
+		"longest": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+			"integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
+			"dev": true
+		},
+		"lowercase-keys": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
+			"integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
+			"dev": true
+		},
+		"lru-cache": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.2.tgz",
+			"integrity": "sha512-wgeVXhrDwAWnIF/yZARsFnMBtdFXOg1b8RIrhilp+0iDYN4mdQcNZElDZ0e4B64BhaxeQ5zN7PMyvu7we1kPeQ==",
+			"dev": true,
+			"requires": {
+				"pseudomap": "1.0.2",
+				"yallist": "2.1.2"
+			}
+		},
+		"make-dir": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.2.0.tgz",
+			"integrity": "sha512-aNUAa4UMg/UougV25bbrU4ZaaKNjJ/3/xnvg/twpmKROPdKZPZ9wGgI0opdZzO8q/zUFawoUuixuOv33eZ61Iw==",
+			"dev": true,
+			"requires": {
+				"pify": "3.0.0"
+			},
+			"dependencies": {
+				"pify": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+					"dev": true
+				}
+			}
+		},
+		"markdown-it": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-7.0.1.tgz",
+			"integrity": "sha1-8S2LiKk+ZCVDSN/Rg71wv2BWekI=",
+			"dev": true,
+			"requires": {
+				"argparse": "1.0.10",
+				"entities": "1.1.1",
+				"linkify-it": "2.0.3",
+				"mdurl": "1.0.1",
+				"uc.micro": "1.0.5"
+			}
+		},
+		"mdurl": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
+			"integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4=",
+			"dev": true
+		},
+		"mime": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+			"integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
+		},
+		"mime-db": {
+			"version": "1.33.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+			"integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ==",
+			"dev": true
+		},
+		"mime-types": {
+			"version": "2.1.18",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+			"integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+			"dev": true,
+			"requires": {
+				"mime-db": "1.33.0"
+			}
+		},
+		"mimic-fn": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+			"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+			"dev": true
+		},
+		"minimatch": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"requires": {
+				"brace-expansion": "1.1.11"
+			}
+		},
+		"minimist": {
+			"version": "0.0.8",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+		},
+		"mkdirp": {
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+			"integrity": "sha1-HXMHam35hs2TROFecfzAWkyavxI=",
+			"requires": {
+				"minimist": "0.0.8"
+			}
+		},
+		"ms": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+		},
+		"mute-stream": {
+			"version": "0.0.7",
+			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+			"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+			"dev": true
+		},
+		"natural-compare": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+			"dev": true
+		},
+		"npm-run-path": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+			"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+			"dev": true,
+			"requires": {
+				"path-key": "2.0.1"
+			}
+		},
+		"nyc": {
+			"version": "11.6.0",
+			"resolved": "https://registry.npmjs.org/nyc/-/nyc-11.6.0.tgz",
+			"integrity": "sha512-ZaXCh0wmbk2aSBH2B5hZGGvK2s9aM8DIm2rVY+BG3Fx8tUS+bpJSswUVZqOD1YfCmnYRFSqgYJSr7UeeUcW0jg==",
+			"requires": {
+				"archy": "1.0.0",
+				"arrify": "1.0.1",
+				"caching-transform": "1.0.1",
+				"convert-source-map": "1.5.1",
+				"debug-log": "1.0.1",
+				"default-require-extensions": "1.0.0",
+				"find-cache-dir": "0.1.1",
+				"find-up": "2.1.0",
+				"foreground-child": "1.5.6",
+				"glob": "7.1.2",
+				"istanbul-lib-coverage": "1.2.0",
+				"istanbul-lib-hook": "1.1.0",
+				"istanbul-lib-instrument": "1.10.1",
+				"istanbul-lib-report": "1.1.3",
+				"istanbul-lib-source-maps": "1.2.3",
+				"istanbul-reports": "1.3.0",
+				"md5-hex": "1.3.0",
+				"merge-source-map": "1.1.0",
+				"micromatch": "2.3.11",
+				"mkdirp": "0.5.1",
+				"resolve-from": "2.0.0",
+				"rimraf": "2.6.2",
+				"signal-exit": "3.0.2",
+				"spawn-wrap": "1.4.2",
+				"test-exclude": "4.2.1",
+				"yargs": "11.1.0",
+				"yargs-parser": "8.1.0"
+			},
+			"dependencies": {
+				"align-text": {
+					"version": "0.1.4",
+					"bundled": true,
+					"requires": {
+						"kind-of": "3.2.2",
+						"longest": "1.0.1",
+						"repeat-string": "1.6.1"
+					}
+				},
+				"amdefine": {
+					"version": "1.0.1",
+					"bundled": true
+				},
+				"ansi-regex": {
+					"version": "2.1.1",
+					"bundled": true
+				},
+				"ansi-styles": {
+					"version": "2.2.1",
+					"bundled": true
+				},
+				"append-transform": {
+					"version": "0.4.0",
+					"bundled": true,
+					"requires": {
+						"default-require-extensions": "1.0.0"
+					}
+				},
+				"archy": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"arr-diff": {
+					"version": "2.0.0",
+					"bundled": true,
+					"requires": {
+						"arr-flatten": "1.1.0"
+					}
+				},
+				"arr-flatten": {
+					"version": "1.1.0",
+					"bundled": true
+				},
+				"arr-union": {
+					"version": "3.1.0",
+					"bundled": true
+				},
+				"array-unique": {
+					"version": "0.2.1",
+					"bundled": true
+				},
+				"arrify": {
+					"version": "1.0.1",
+					"bundled": true
+				},
+				"assign-symbols": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"async": {
+					"version": "1.5.2",
+					"bundled": true
+				},
+				"atob": {
+					"version": "2.0.3",
+					"bundled": true
+				},
+				"babel-code-frame": {
+					"version": "6.26.0",
+					"bundled": true,
+					"requires": {
+						"chalk": "1.1.3",
+						"esutils": "2.0.2",
+						"js-tokens": "3.0.2"
+					}
+				},
+				"babel-generator": {
+					"version": "6.26.1",
+					"bundled": true,
+					"requires": {
+						"babel-messages": "6.23.0",
+						"babel-runtime": "6.26.0",
+						"babel-types": "6.26.0",
+						"detect-indent": "4.0.0",
+						"jsesc": "1.3.0",
+						"lodash": "4.17.5",
+						"source-map": "0.5.7",
+						"trim-right": "1.0.1"
+					}
+				},
+				"babel-messages": {
+					"version": "6.23.0",
+					"bundled": true,
+					"requires": {
+						"babel-runtime": "6.26.0"
+					}
+				},
+				"babel-runtime": {
+					"version": "6.26.0",
+					"bundled": true,
+					"requires": {
+						"core-js": "2.5.3",
+						"regenerator-runtime": "0.11.1"
+					}
+				},
+				"babel-template": {
+					"version": "6.26.0",
+					"bundled": true,
+					"requires": {
+						"babel-runtime": "6.26.0",
+						"babel-traverse": "6.26.0",
+						"babel-types": "6.26.0",
+						"babylon": "6.18.0",
+						"lodash": "4.17.5"
+					}
+				},
+				"babel-traverse": {
+					"version": "6.26.0",
+					"bundled": true,
+					"requires": {
+						"babel-code-frame": "6.26.0",
+						"babel-messages": "6.23.0",
+						"babel-runtime": "6.26.0",
+						"babel-types": "6.26.0",
+						"babylon": "6.18.0",
+						"debug": "2.6.9",
+						"globals": "9.18.0",
+						"invariant": "2.2.3",
+						"lodash": "4.17.5"
+					}
+				},
+				"babel-types": {
+					"version": "6.26.0",
+					"bundled": true,
+					"requires": {
+						"babel-runtime": "6.26.0",
+						"esutils": "2.0.2",
+						"lodash": "4.17.5",
+						"to-fast-properties": "1.0.3"
+					}
+				},
+				"babylon": {
+					"version": "6.18.0",
+					"bundled": true
+				},
+				"balanced-match": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"base": {
+					"version": "0.11.2",
+					"bundled": true,
+					"requires": {
+						"cache-base": "1.0.1",
+						"class-utils": "0.3.6",
+						"component-emitter": "1.2.1",
+						"define-property": "1.0.0",
+						"isobject": "3.0.1",
+						"mixin-deep": "1.3.1",
+						"pascalcase": "0.1.1"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "1.0.0",
+							"bundled": true,
+							"requires": {
+								"is-descriptor": "1.0.2"
+							}
+						},
+						"isobject": {
+							"version": "3.0.1",
+							"bundled": true
+						}
+					}
+				},
+				"brace-expansion": {
+					"version": "1.1.11",
+					"bundled": true,
+					"requires": {
+						"balanced-match": "1.0.0",
+						"concat-map": "0.0.1"
+					}
+				},
+				"braces": {
+					"version": "1.8.5",
+					"bundled": true,
+					"requires": {
+						"expand-range": "1.8.2",
+						"preserve": "0.2.0",
+						"repeat-element": "1.1.2"
+					}
+				},
+				"builtin-modules": {
+					"version": "1.1.1",
+					"bundled": true
+				},
+				"cache-base": {
+					"version": "1.0.1",
+					"bundled": true,
+					"requires": {
+						"collection-visit": "1.0.0",
+						"component-emitter": "1.2.1",
+						"get-value": "2.0.6",
+						"has-value": "1.0.0",
+						"isobject": "3.0.1",
+						"set-value": "2.0.0",
+						"to-object-path": "0.3.0",
+						"union-value": "1.0.0",
+						"unset-value": "1.0.0"
+					},
+					"dependencies": {
+						"isobject": {
+							"version": "3.0.1",
+							"bundled": true
+						}
+					}
+				},
+				"caching-transform": {
+					"version": "1.0.1",
+					"bundled": true,
+					"requires": {
+						"md5-hex": "1.3.0",
+						"mkdirp": "0.5.1",
+						"write-file-atomic": "1.3.4"
+					}
+				},
+				"camelcase": {
+					"version": "1.2.1",
+					"bundled": true,
+					"optional": true
+				},
+				"center-align": {
+					"version": "0.1.3",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"align-text": "0.1.4",
+						"lazy-cache": "1.0.4"
+					}
+				},
+				"chalk": {
+					"version": "1.1.3",
+					"bundled": true,
+					"requires": {
+						"ansi-styles": "2.2.1",
+						"escape-string-regexp": "1.0.5",
+						"has-ansi": "2.0.0",
+						"strip-ansi": "3.0.1",
+						"supports-color": "2.0.0"
+					}
+				},
+				"class-utils": {
+					"version": "0.3.6",
+					"bundled": true,
+					"requires": {
+						"arr-union": "3.1.0",
+						"define-property": "0.2.5",
+						"isobject": "3.0.1",
+						"static-extend": "0.1.2"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "0.2.5",
+							"bundled": true,
+							"requires": {
+								"is-descriptor": "0.1.6"
+							}
+						},
+						"is-accessor-descriptor": {
+							"version": "0.1.6",
+							"bundled": true,
+							"requires": {
+								"kind-of": "3.2.2"
+							},
+							"dependencies": {
+								"kind-of": {
+									"version": "3.2.2",
+									"bundled": true,
+									"requires": {
+										"is-buffer": "1.1.6"
+									}
+								}
+							}
+						},
+						"is-data-descriptor": {
+							"version": "0.1.4",
+							"bundled": true,
+							"requires": {
+								"kind-of": "3.2.2"
+							},
+							"dependencies": {
+								"kind-of": {
+									"version": "3.2.2",
+									"bundled": true,
+									"requires": {
+										"is-buffer": "1.1.6"
+									}
+								}
+							}
+						},
+						"is-descriptor": {
+							"version": "0.1.6",
+							"bundled": true,
+							"requires": {
+								"is-accessor-descriptor": "0.1.6",
+								"is-data-descriptor": "0.1.4",
+								"kind-of": "5.1.0"
+							}
+						},
+						"isobject": {
+							"version": "3.0.1",
+							"bundled": true
+						},
+						"kind-of": {
+							"version": "5.1.0",
+							"bundled": true
+						}
+					}
+				},
+				"cliui": {
+					"version": "2.1.0",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"center-align": "0.1.3",
+						"right-align": "0.1.3",
+						"wordwrap": "0.0.2"
+					},
+					"dependencies": {
+						"wordwrap": {
+							"version": "0.0.2",
+							"bundled": true,
+							"optional": true
+						}
+					}
+				},
+				"code-point-at": {
+					"version": "1.1.0",
+					"bundled": true
+				},
+				"collection-visit": {
+					"version": "1.0.0",
+					"bundled": true,
+					"requires": {
+						"map-visit": "1.0.0",
+						"object-visit": "1.0.1"
+					}
+				},
+				"commondir": {
+					"version": "1.0.1",
+					"bundled": true
+				},
+				"component-emitter": {
+					"version": "1.2.1",
+					"bundled": true
+				},
+				"concat-map": {
+					"version": "0.0.1",
+					"bundled": true
+				},
+				"convert-source-map": {
+					"version": "1.5.1",
+					"bundled": true
+				},
+				"copy-descriptor": {
+					"version": "0.1.1",
+					"bundled": true
+				},
+				"core-js": {
+					"version": "2.5.3",
+					"bundled": true
+				},
+				"cross-spawn": {
+					"version": "4.0.2",
+					"bundled": true,
+					"requires": {
+						"lru-cache": "4.1.2",
+						"which": "1.3.0"
+					}
+				},
+				"debug": {
+					"version": "2.6.9",
+					"bundled": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"debug-log": {
+					"version": "1.0.1",
+					"bundled": true
+				},
+				"decamelize": {
+					"version": "1.2.0",
+					"bundled": true
+				},
+				"decode-uri-component": {
+					"version": "0.2.0",
+					"bundled": true
+				},
+				"default-require-extensions": {
+					"version": "1.0.0",
+					"bundled": true,
+					"requires": {
+						"strip-bom": "2.0.0"
+					}
+				},
+				"define-property": {
+					"version": "2.0.2",
+					"bundled": true,
+					"requires": {
+						"is-descriptor": "1.0.2",
+						"isobject": "3.0.1"
+					},
+					"dependencies": {
+						"isobject": {
+							"version": "3.0.1",
+							"bundled": true
+						}
+					}
+				},
+				"detect-indent": {
+					"version": "4.0.0",
+					"bundled": true,
+					"requires": {
+						"repeating": "2.0.1"
+					}
+				},
+				"error-ex": {
+					"version": "1.3.1",
+					"bundled": true,
+					"requires": {
+						"is-arrayish": "0.2.1"
+					}
+				},
+				"escape-string-regexp": {
+					"version": "1.0.5",
+					"bundled": true
+				},
+				"esutils": {
+					"version": "2.0.2",
+					"bundled": true
+				},
+				"execa": {
+					"version": "0.7.0",
+					"bundled": true,
+					"requires": {
+						"cross-spawn": "5.1.0",
+						"get-stream": "3.0.0",
+						"is-stream": "1.1.0",
+						"npm-run-path": "2.0.2",
+						"p-finally": "1.0.0",
+						"signal-exit": "3.0.2",
+						"strip-eof": "1.0.0"
+					},
+					"dependencies": {
+						"cross-spawn": {
+							"version": "5.1.0",
+							"bundled": true,
+							"requires": {
+								"lru-cache": "4.1.2",
+								"shebang-command": "1.2.0",
+								"which": "1.3.0"
+							}
+						}
+					}
+				},
+				"expand-brackets": {
+					"version": "0.1.5",
+					"bundled": true,
+					"requires": {
+						"is-posix-bracket": "0.1.1"
+					}
+				},
+				"expand-range": {
+					"version": "1.8.2",
+					"bundled": true,
+					"requires": {
+						"fill-range": "2.2.3"
+					}
+				},
+				"extend-shallow": {
+					"version": "3.0.2",
+					"bundled": true,
+					"requires": {
+						"assign-symbols": "1.0.0",
+						"is-extendable": "1.0.1"
+					},
+					"dependencies": {
+						"is-extendable": {
+							"version": "1.0.1",
+							"bundled": true,
+							"requires": {
+								"is-plain-object": "2.0.4"
+							}
+						}
+					}
+				},
+				"extglob": {
+					"version": "0.3.2",
+					"bundled": true,
+					"requires": {
+						"is-extglob": "1.0.0"
+					}
+				},
+				"filename-regex": {
+					"version": "2.0.1",
+					"bundled": true
+				},
+				"fill-range": {
+					"version": "2.2.3",
+					"bundled": true,
+					"requires": {
+						"is-number": "2.1.0",
+						"isobject": "2.1.0",
+						"randomatic": "1.1.7",
+						"repeat-element": "1.1.2",
+						"repeat-string": "1.6.1"
+					}
+				},
+				"find-cache-dir": {
+					"version": "0.1.1",
+					"bundled": true,
+					"requires": {
+						"commondir": "1.0.1",
+						"mkdirp": "0.5.1",
+						"pkg-dir": "1.0.0"
+					}
+				},
+				"find-up": {
+					"version": "2.1.0",
+					"bundled": true,
+					"requires": {
+						"locate-path": "2.0.0"
+					}
+				},
+				"for-in": {
+					"version": "1.0.2",
+					"bundled": true
+				},
+				"for-own": {
+					"version": "0.1.5",
+					"bundled": true,
+					"requires": {
+						"for-in": "1.0.2"
+					}
+				},
+				"foreground-child": {
+					"version": "1.5.6",
+					"bundled": true,
+					"requires": {
+						"cross-spawn": "4.0.2",
+						"signal-exit": "3.0.2"
+					}
+				},
+				"fragment-cache": {
+					"version": "0.2.1",
+					"bundled": true,
+					"requires": {
+						"map-cache": "0.2.2"
+					}
+				},
+				"fs.realpath": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"get-caller-file": {
+					"version": "1.0.2",
+					"bundled": true
+				},
+				"get-stream": {
+					"version": "3.0.0",
+					"bundled": true
+				},
+				"get-value": {
+					"version": "2.0.6",
+					"bundled": true
+				},
+				"glob": {
+					"version": "7.1.2",
+					"bundled": true,
+					"requires": {
+						"fs.realpath": "1.0.0",
+						"inflight": "1.0.6",
+						"inherits": "2.0.3",
+						"minimatch": "3.0.4",
+						"once": "1.4.0",
+						"path-is-absolute": "1.0.1"
+					}
+				},
+				"glob-base": {
+					"version": "0.3.0",
+					"bundled": true,
+					"requires": {
+						"glob-parent": "2.0.0",
+						"is-glob": "2.0.1"
+					}
+				},
+				"glob-parent": {
+					"version": "2.0.0",
+					"bundled": true,
+					"requires": {
+						"is-glob": "2.0.1"
+					}
+				},
+				"globals": {
+					"version": "9.18.0",
+					"bundled": true
+				},
+				"graceful-fs": {
+					"version": "4.1.11",
+					"bundled": true
+				},
+				"handlebars": {
+					"version": "4.0.11",
+					"bundled": true,
+					"requires": {
+						"async": "1.5.2",
+						"optimist": "0.6.1",
+						"source-map": "0.4.4",
+						"uglify-js": "2.8.29"
+					},
+					"dependencies": {
+						"source-map": {
+							"version": "0.4.4",
+							"bundled": true,
+							"requires": {
+								"amdefine": "1.0.1"
+							}
+						}
+					}
+				},
+				"has-ansi": {
+					"version": "2.0.0",
+					"bundled": true,
+					"requires": {
+						"ansi-regex": "2.1.1"
+					}
+				},
+				"has-flag": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"has-value": {
+					"version": "1.0.0",
+					"bundled": true,
+					"requires": {
+						"get-value": "2.0.6",
+						"has-values": "1.0.0",
+						"isobject": "3.0.1"
+					},
+					"dependencies": {
+						"isobject": {
+							"version": "3.0.1",
+							"bundled": true
+						}
+					}
+				},
+				"has-values": {
+					"version": "1.0.0",
+					"bundled": true,
+					"requires": {
+						"is-number": "3.0.0",
+						"kind-of": "4.0.0"
+					},
+					"dependencies": {
+						"is-number": {
+							"version": "3.0.0",
+							"bundled": true,
+							"requires": {
+								"kind-of": "3.2.2"
+							},
+							"dependencies": {
+								"kind-of": {
+									"version": "3.2.2",
+									"bundled": true,
+									"requires": {
+										"is-buffer": "1.1.6"
+									}
+								}
+							}
+						},
+						"kind-of": {
+							"version": "4.0.0",
+							"bundled": true,
+							"requires": {
+								"is-buffer": "1.1.6"
+							}
+						}
+					}
+				},
+				"hosted-git-info": {
+					"version": "2.6.0",
+					"bundled": true
+				},
+				"imurmurhash": {
+					"version": "0.1.4",
+					"bundled": true
+				},
+				"inflight": {
+					"version": "1.0.6",
+					"bundled": true,
+					"requires": {
+						"once": "1.4.0",
+						"wrappy": "1.0.2"
+					}
+				},
+				"inherits": {
+					"version": "2.0.3",
+					"bundled": true
+				},
+				"invariant": {
+					"version": "2.2.3",
+					"bundled": true,
+					"requires": {
+						"loose-envify": "1.3.1"
+					}
+				},
+				"invert-kv": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"is-accessor-descriptor": {
+					"version": "1.0.0",
+					"bundled": true,
+					"requires": {
+						"kind-of": "6.0.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "6.0.2",
+							"bundled": true
+						}
+					}
+				},
+				"is-arrayish": {
+					"version": "0.2.1",
+					"bundled": true
+				},
+				"is-buffer": {
+					"version": "1.1.6",
+					"bundled": true
+				},
+				"is-builtin-module": {
+					"version": "1.0.0",
+					"bundled": true,
+					"requires": {
+						"builtin-modules": "1.1.1"
+					}
+				},
+				"is-data-descriptor": {
+					"version": "1.0.0",
+					"bundled": true,
+					"requires": {
+						"kind-of": "6.0.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "6.0.2",
+							"bundled": true
+						}
+					}
+				},
+				"is-descriptor": {
+					"version": "1.0.2",
+					"bundled": true,
+					"requires": {
+						"is-accessor-descriptor": "1.0.0",
+						"is-data-descriptor": "1.0.0",
+						"kind-of": "6.0.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "6.0.2",
+							"bundled": true
+						}
+					}
+				},
+				"is-dotfile": {
+					"version": "1.0.3",
+					"bundled": true
+				},
+				"is-equal-shallow": {
+					"version": "0.1.3",
+					"bundled": true,
+					"requires": {
+						"is-primitive": "2.0.0"
+					}
+				},
+				"is-extendable": {
+					"version": "0.1.1",
+					"bundled": true
+				},
+				"is-extglob": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"is-finite": {
+					"version": "1.0.2",
+					"bundled": true,
+					"requires": {
+						"number-is-nan": "1.0.1"
+					}
+				},
+				"is-fullwidth-code-point": {
+					"version": "2.0.0",
+					"bundled": true
+				},
+				"is-glob": {
+					"version": "2.0.1",
+					"bundled": true,
+					"requires": {
+						"is-extglob": "1.0.0"
+					}
+				},
+				"is-number": {
+					"version": "2.1.0",
+					"bundled": true,
+					"requires": {
+						"kind-of": "3.2.2"
+					}
+				},
+				"is-odd": {
+					"version": "2.0.0",
+					"bundled": true,
+					"requires": {
+						"is-number": "4.0.0"
+					},
+					"dependencies": {
+						"is-number": {
+							"version": "4.0.0",
+							"bundled": true
+						}
+					}
+				},
+				"is-plain-object": {
+					"version": "2.0.4",
+					"bundled": true,
+					"requires": {
+						"isobject": "3.0.1"
+					},
+					"dependencies": {
+						"isobject": {
+							"version": "3.0.1",
+							"bundled": true
+						}
+					}
+				},
+				"is-posix-bracket": {
+					"version": "0.1.1",
+					"bundled": true
+				},
+				"is-primitive": {
+					"version": "2.0.0",
+					"bundled": true
+				},
+				"is-stream": {
+					"version": "1.1.0",
+					"bundled": true
+				},
+				"is-utf8": {
+					"version": "0.2.1",
+					"bundled": true
+				},
+				"is-windows": {
+					"version": "1.0.2",
+					"bundled": true
+				},
+				"isarray": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"isexe": {
+					"version": "2.0.0",
+					"bundled": true
+				},
+				"isobject": {
+					"version": "2.1.0",
+					"bundled": true,
+					"requires": {
+						"isarray": "1.0.0"
+					}
+				},
+				"istanbul-lib-coverage": {
+					"version": "1.2.0",
+					"bundled": true
+				},
+				"istanbul-lib-hook": {
+					"version": "1.1.0",
+					"bundled": true,
+					"requires": {
+						"append-transform": "0.4.0"
+					}
+				},
+				"istanbul-lib-instrument": {
+					"version": "1.10.1",
+					"bundled": true,
+					"requires": {
+						"babel-generator": "6.26.1",
+						"babel-template": "6.26.0",
+						"babel-traverse": "6.26.0",
+						"babel-types": "6.26.0",
+						"babylon": "6.18.0",
+						"istanbul-lib-coverage": "1.2.0",
+						"semver": "5.5.0"
+					}
+				},
+				"istanbul-lib-report": {
+					"version": "1.1.3",
+					"bundled": true,
+					"requires": {
+						"istanbul-lib-coverage": "1.2.0",
+						"mkdirp": "0.5.1",
+						"path-parse": "1.0.5",
+						"supports-color": "3.2.3"
+					},
+					"dependencies": {
+						"supports-color": {
+							"version": "3.2.3",
+							"bundled": true,
+							"requires": {
+								"has-flag": "1.0.0"
+							}
+						}
+					}
+				},
+				"istanbul-lib-source-maps": {
+					"version": "1.2.3",
+					"bundled": true,
+					"requires": {
+						"debug": "3.1.0",
+						"istanbul-lib-coverage": "1.2.0",
+						"mkdirp": "0.5.1",
+						"rimraf": "2.6.2",
+						"source-map": "0.5.7"
+					},
+					"dependencies": {
+						"debug": {
+							"version": "3.1.0",
+							"bundled": true,
+							"requires": {
+								"ms": "2.0.0"
+							}
+						}
+					}
+				},
+				"istanbul-reports": {
+					"version": "1.3.0",
+					"bundled": true,
+					"requires": {
+						"handlebars": "4.0.11"
+					}
+				},
+				"js-tokens": {
+					"version": "3.0.2",
+					"bundled": true
+				},
+				"jsesc": {
+					"version": "1.3.0",
+					"bundled": true
+				},
+				"kind-of": {
+					"version": "3.2.2",
+					"bundled": true,
+					"requires": {
+						"is-buffer": "1.1.6"
+					}
+				},
+				"lazy-cache": {
+					"version": "1.0.4",
+					"bundled": true,
+					"optional": true
+				},
+				"lcid": {
+					"version": "1.0.0",
+					"bundled": true,
+					"requires": {
+						"invert-kv": "1.0.0"
+					}
+				},
+				"load-json-file": {
+					"version": "1.1.0",
+					"bundled": true,
+					"requires": {
+						"graceful-fs": "4.1.11",
+						"parse-json": "2.2.0",
+						"pify": "2.3.0",
+						"pinkie-promise": "2.0.1",
+						"strip-bom": "2.0.0"
+					}
+				},
+				"locate-path": {
+					"version": "2.0.0",
+					"bundled": true,
+					"requires": {
+						"p-locate": "2.0.0",
+						"path-exists": "3.0.0"
+					},
+					"dependencies": {
+						"path-exists": {
+							"version": "3.0.0",
+							"bundled": true
+						}
+					}
+				},
+				"lodash": {
+					"version": "4.17.5",
+					"bundled": true
+				},
+				"longest": {
+					"version": "1.0.1",
+					"bundled": true
+				},
+				"loose-envify": {
+					"version": "1.3.1",
+					"bundled": true,
+					"requires": {
+						"js-tokens": "3.0.2"
+					}
+				},
+				"lru-cache": {
+					"version": "4.1.2",
+					"bundled": true,
+					"requires": {
+						"pseudomap": "1.0.2",
+						"yallist": "2.1.2"
+					}
+				},
+				"map-cache": {
+					"version": "0.2.2",
+					"bundled": true
+				},
+				"map-visit": {
+					"version": "1.0.0",
+					"bundled": true,
+					"requires": {
+						"object-visit": "1.0.1"
+					}
+				},
+				"md5-hex": {
+					"version": "1.3.0",
+					"bundled": true,
+					"requires": {
+						"md5-o-matic": "0.1.1"
+					}
+				},
+				"md5-o-matic": {
+					"version": "0.1.1",
+					"bundled": true
+				},
+				"mem": {
+					"version": "1.1.0",
+					"bundled": true,
+					"requires": {
+						"mimic-fn": "1.2.0"
+					}
+				},
+				"merge-source-map": {
+					"version": "1.1.0",
+					"bundled": true,
+					"requires": {
+						"source-map": "0.6.1"
+					},
+					"dependencies": {
+						"source-map": {
+							"version": "0.6.1",
+							"bundled": true
+						}
+					}
+				},
+				"micromatch": {
+					"version": "2.3.11",
+					"bundled": true,
+					"requires": {
+						"arr-diff": "2.0.0",
+						"array-unique": "0.2.1",
+						"braces": "1.8.5",
+						"expand-brackets": "0.1.5",
+						"extglob": "0.3.2",
+						"filename-regex": "2.0.1",
+						"is-extglob": "1.0.0",
+						"is-glob": "2.0.1",
+						"kind-of": "3.2.2",
+						"normalize-path": "2.1.1",
+						"object.omit": "2.0.1",
+						"parse-glob": "3.0.4",
+						"regex-cache": "0.4.4"
+					}
+				},
+				"mimic-fn": {
+					"version": "1.2.0",
+					"bundled": true
+				},
+				"minimatch": {
+					"version": "3.0.4",
+					"bundled": true,
+					"requires": {
+						"brace-expansion": "1.1.11"
+					}
+				},
+				"minimist": {
+					"version": "0.0.8",
+					"bundled": true
+				},
+				"mixin-deep": {
+					"version": "1.3.1",
+					"bundled": true,
+					"requires": {
+						"for-in": "1.0.2",
+						"is-extendable": "1.0.1"
+					},
+					"dependencies": {
+						"is-extendable": {
+							"version": "1.0.1",
+							"bundled": true,
+							"requires": {
+								"is-plain-object": "2.0.4"
+							}
+						}
+					}
+				},
+				"mkdirp": {
+					"version": "0.5.1",
+					"bundled": true,
+					"requires": {
+						"minimist": "0.0.8"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"bundled": true
+				},
+				"nanomatch": {
+					"version": "1.2.9",
+					"bundled": true,
+					"requires": {
+						"arr-diff": "4.0.0",
+						"array-unique": "0.3.2",
+						"define-property": "2.0.2",
+						"extend-shallow": "3.0.2",
+						"fragment-cache": "0.2.1",
+						"is-odd": "2.0.0",
+						"is-windows": "1.0.2",
+						"kind-of": "6.0.2",
+						"object.pick": "1.3.0",
+						"regex-not": "1.0.2",
+						"snapdragon": "0.8.2",
+						"to-regex": "3.0.2"
+					},
+					"dependencies": {
+						"arr-diff": {
+							"version": "4.0.0",
+							"bundled": true
+						},
+						"array-unique": {
+							"version": "0.3.2",
+							"bundled": true
+						},
+						"kind-of": {
+							"version": "6.0.2",
+							"bundled": true
+						}
+					}
+				},
+				"normalize-package-data": {
+					"version": "2.4.0",
+					"bundled": true,
+					"requires": {
+						"hosted-git-info": "2.6.0",
+						"is-builtin-module": "1.0.0",
+						"semver": "5.5.0",
+						"validate-npm-package-license": "3.0.3"
+					}
+				},
+				"normalize-path": {
+					"version": "2.1.1",
+					"bundled": true,
+					"requires": {
+						"remove-trailing-separator": "1.1.0"
+					}
+				},
+				"npm-run-path": {
+					"version": "2.0.2",
+					"bundled": true,
+					"requires": {
+						"path-key": "2.0.1"
+					}
+				},
+				"number-is-nan": {
+					"version": "1.0.1",
+					"bundled": true
+				},
+				"object-assign": {
+					"version": "4.1.1",
+					"bundled": true
+				},
+				"object-copy": {
+					"version": "0.1.0",
+					"bundled": true,
+					"requires": {
+						"copy-descriptor": "0.1.1",
+						"define-property": "0.2.5",
+						"kind-of": "3.2.2"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "0.2.5",
+							"bundled": true,
+							"requires": {
+								"is-descriptor": "0.1.6"
+							}
+						},
+						"is-accessor-descriptor": {
+							"version": "0.1.6",
+							"bundled": true,
+							"requires": {
+								"kind-of": "3.2.2"
+							}
+						},
+						"is-data-descriptor": {
+							"version": "0.1.4",
+							"bundled": true,
+							"requires": {
+								"kind-of": "3.2.2"
+							}
+						},
+						"is-descriptor": {
+							"version": "0.1.6",
+							"bundled": true,
+							"requires": {
+								"is-accessor-descriptor": "0.1.6",
+								"is-data-descriptor": "0.1.4",
+								"kind-of": "5.1.0"
+							},
+							"dependencies": {
+								"kind-of": {
+									"version": "5.1.0",
+									"bundled": true
+								}
+							}
+						}
+					}
+				},
+				"object-visit": {
+					"version": "1.0.1",
+					"bundled": true,
+					"requires": {
+						"isobject": "3.0.1"
+					},
+					"dependencies": {
+						"isobject": {
+							"version": "3.0.1",
+							"bundled": true
+						}
+					}
+				},
+				"object.omit": {
+					"version": "2.0.1",
+					"bundled": true,
+					"requires": {
+						"for-own": "0.1.5",
+						"is-extendable": "0.1.1"
+					}
+				},
+				"object.pick": {
+					"version": "1.3.0",
+					"bundled": true,
+					"requires": {
+						"isobject": "3.0.1"
+					},
+					"dependencies": {
+						"isobject": {
+							"version": "3.0.1",
+							"bundled": true
+						}
+					}
+				},
+				"once": {
+					"version": "1.4.0",
+					"bundled": true,
+					"requires": {
+						"wrappy": "1.0.2"
+					}
+				},
+				"optimist": {
+					"version": "0.6.1",
+					"bundled": true,
+					"requires": {
+						"minimist": "0.0.8",
+						"wordwrap": "0.0.3"
+					}
+				},
+				"os-homedir": {
+					"version": "1.0.2",
+					"bundled": true
+				},
+				"os-locale": {
+					"version": "2.1.0",
+					"bundled": true,
+					"requires": {
+						"execa": "0.7.0",
+						"lcid": "1.0.0",
+						"mem": "1.1.0"
+					}
+				},
+				"p-finally": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"p-limit": {
+					"version": "1.2.0",
+					"bundled": true,
+					"requires": {
+						"p-try": "1.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "2.0.0",
+					"bundled": true,
+					"requires": {
+						"p-limit": "1.2.0"
+					}
+				},
+				"p-try": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"parse-glob": {
+					"version": "3.0.4",
+					"bundled": true,
+					"requires": {
+						"glob-base": "0.3.0",
+						"is-dotfile": "1.0.3",
+						"is-extglob": "1.0.0",
+						"is-glob": "2.0.1"
+					}
+				},
+				"parse-json": {
+					"version": "2.2.0",
+					"bundled": true,
+					"requires": {
+						"error-ex": "1.3.1"
+					}
+				},
+				"pascalcase": {
+					"version": "0.1.1",
+					"bundled": true
+				},
+				"path-exists": {
+					"version": "2.1.0",
+					"bundled": true,
+					"requires": {
+						"pinkie-promise": "2.0.1"
+					}
+				},
+				"path-is-absolute": {
+					"version": "1.0.1",
+					"bundled": true
+				},
+				"path-key": {
+					"version": "2.0.1",
+					"bundled": true
+				},
+				"path-parse": {
+					"version": "1.0.5",
+					"bundled": true
+				},
+				"path-type": {
+					"version": "1.1.0",
+					"bundled": true,
+					"requires": {
+						"graceful-fs": "4.1.11",
+						"pify": "2.3.0",
+						"pinkie-promise": "2.0.1"
+					}
+				},
+				"pify": {
+					"version": "2.3.0",
+					"bundled": true
+				},
+				"pinkie": {
+					"version": "2.0.4",
+					"bundled": true
+				},
+				"pinkie-promise": {
+					"version": "2.0.1",
+					"bundled": true,
+					"requires": {
+						"pinkie": "2.0.4"
+					}
+				},
+				"pkg-dir": {
+					"version": "1.0.0",
+					"bundled": true,
+					"requires": {
+						"find-up": "1.1.2"
+					},
+					"dependencies": {
+						"find-up": {
+							"version": "1.1.2",
+							"bundled": true,
+							"requires": {
+								"path-exists": "2.1.0",
+								"pinkie-promise": "2.0.1"
+							}
+						}
+					}
+				},
+				"posix-character-classes": {
+					"version": "0.1.1",
+					"bundled": true
+				},
+				"preserve": {
+					"version": "0.2.0",
+					"bundled": true
+				},
+				"pseudomap": {
+					"version": "1.0.2",
+					"bundled": true
+				},
+				"randomatic": {
+					"version": "1.1.7",
+					"bundled": true,
+					"requires": {
+						"is-number": "3.0.0",
+						"kind-of": "4.0.0"
+					},
+					"dependencies": {
+						"is-number": {
+							"version": "3.0.0",
+							"bundled": true,
+							"requires": {
+								"kind-of": "3.2.2"
+							},
+							"dependencies": {
+								"kind-of": {
+									"version": "3.2.2",
+									"bundled": true,
+									"requires": {
+										"is-buffer": "1.1.6"
+									}
+								}
+							}
+						},
+						"kind-of": {
+							"version": "4.0.0",
+							"bundled": true,
+							"requires": {
+								"is-buffer": "1.1.6"
+							}
+						}
+					}
+				},
+				"read-pkg": {
+					"version": "1.1.0",
+					"bundled": true,
+					"requires": {
+						"load-json-file": "1.1.0",
+						"normalize-package-data": "2.4.0",
+						"path-type": "1.1.0"
+					}
+				},
+				"read-pkg-up": {
+					"version": "1.0.1",
+					"bundled": true,
+					"requires": {
+						"find-up": "1.1.2",
+						"read-pkg": "1.1.0"
+					},
+					"dependencies": {
+						"find-up": {
+							"version": "1.1.2",
+							"bundled": true,
+							"requires": {
+								"path-exists": "2.1.0",
+								"pinkie-promise": "2.0.1"
+							}
+						}
+					}
+				},
+				"regenerator-runtime": {
+					"version": "0.11.1",
+					"bundled": true
+				},
+				"regex-cache": {
+					"version": "0.4.4",
+					"bundled": true,
+					"requires": {
+						"is-equal-shallow": "0.1.3"
+					}
+				},
+				"regex-not": {
+					"version": "1.0.2",
+					"bundled": true,
+					"requires": {
+						"extend-shallow": "3.0.2",
+						"safe-regex": "1.1.0"
+					}
+				},
+				"remove-trailing-separator": {
+					"version": "1.1.0",
+					"bundled": true
+				},
+				"repeat-element": {
+					"version": "1.1.2",
+					"bundled": true
+				},
+				"repeat-string": {
+					"version": "1.6.1",
+					"bundled": true
+				},
+				"repeating": {
+					"version": "2.0.1",
+					"bundled": true,
+					"requires": {
+						"is-finite": "1.0.2"
+					}
+				},
+				"require-directory": {
+					"version": "2.1.1",
+					"bundled": true
+				},
+				"require-main-filename": {
+					"version": "1.0.1",
+					"bundled": true
+				},
+				"resolve-from": {
+					"version": "2.0.0",
+					"bundled": true
+				},
+				"resolve-url": {
+					"version": "0.2.1",
+					"bundled": true
+				},
+				"ret": {
+					"version": "0.1.15",
+					"bundled": true
+				},
+				"right-align": {
+					"version": "0.1.3",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"align-text": "0.1.4"
+					}
+				},
+				"rimraf": {
+					"version": "2.6.2",
+					"bundled": true,
+					"requires": {
+						"glob": "7.1.2"
+					}
+				},
+				"safe-regex": {
+					"version": "1.1.0",
+					"bundled": true,
+					"requires": {
+						"ret": "0.1.15"
+					}
+				},
+				"semver": {
+					"version": "5.5.0",
+					"bundled": true
+				},
+				"set-blocking": {
+					"version": "2.0.0",
+					"bundled": true
+				},
+				"set-value": {
+					"version": "2.0.0",
+					"bundled": true,
+					"requires": {
+						"extend-shallow": "2.0.1",
+						"is-extendable": "0.1.1",
+						"is-plain-object": "2.0.4",
+						"split-string": "3.1.0"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"bundled": true,
+							"requires": {
+								"is-extendable": "0.1.1"
+							}
+						}
+					}
+				},
+				"shebang-command": {
+					"version": "1.2.0",
+					"bundled": true,
+					"requires": {
+						"shebang-regex": "1.0.0"
+					}
+				},
+				"shebang-regex": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"signal-exit": {
+					"version": "3.0.2",
+					"bundled": true
+				},
+				"slide": {
+					"version": "1.1.6",
+					"bundled": true
+				},
+				"snapdragon": {
+					"version": "0.8.2",
+					"bundled": true,
+					"requires": {
+						"base": "0.11.2",
+						"debug": "2.6.9",
+						"define-property": "0.2.5",
+						"extend-shallow": "2.0.1",
+						"map-cache": "0.2.2",
+						"source-map": "0.5.7",
+						"source-map-resolve": "0.5.1",
+						"use": "3.1.0"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "0.2.5",
+							"bundled": true,
+							"requires": {
+								"is-descriptor": "0.1.6"
+							}
+						},
+						"extend-shallow": {
+							"version": "2.0.1",
+							"bundled": true,
+							"requires": {
+								"is-extendable": "0.1.1"
+							}
+						},
+						"is-accessor-descriptor": {
+							"version": "0.1.6",
+							"bundled": true,
+							"requires": {
+								"kind-of": "3.2.2"
+							},
+							"dependencies": {
+								"kind-of": {
+									"version": "3.2.2",
+									"bundled": true,
+									"requires": {
+										"is-buffer": "1.1.6"
+									}
+								}
+							}
+						},
+						"is-data-descriptor": {
+							"version": "0.1.4",
+							"bundled": true,
+							"requires": {
+								"kind-of": "3.2.2"
+							},
+							"dependencies": {
+								"kind-of": {
+									"version": "3.2.2",
+									"bundled": true,
+									"requires": {
+										"is-buffer": "1.1.6"
+									}
+								}
+							}
+						},
+						"is-descriptor": {
+							"version": "0.1.6",
+							"bundled": true,
+							"requires": {
+								"is-accessor-descriptor": "0.1.6",
+								"is-data-descriptor": "0.1.4",
+								"kind-of": "5.1.0"
+							}
+						},
+						"kind-of": {
+							"version": "5.1.0",
+							"bundled": true
+						}
+					}
+				},
+				"snapdragon-node": {
+					"version": "2.1.1",
+					"bundled": true,
+					"requires": {
+						"define-property": "1.0.0",
+						"isobject": "3.0.1",
+						"snapdragon-util": "3.0.1"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "1.0.0",
+							"bundled": true,
+							"requires": {
+								"is-descriptor": "1.0.2"
+							}
+						},
+						"isobject": {
+							"version": "3.0.1",
+							"bundled": true
+						}
+					}
+				},
+				"snapdragon-util": {
+					"version": "3.0.1",
+					"bundled": true,
+					"requires": {
+						"kind-of": "3.2.2"
+					}
+				},
+				"source-map": {
+					"version": "0.5.7",
+					"bundled": true
+				},
+				"source-map-resolve": {
+					"version": "0.5.1",
+					"bundled": true,
+					"requires": {
+						"atob": "2.0.3",
+						"decode-uri-component": "0.2.0",
+						"resolve-url": "0.2.1",
+						"source-map-url": "0.4.0",
+						"urix": "0.1.0"
+					}
+				},
+				"source-map-url": {
+					"version": "0.4.0",
+					"bundled": true
+				},
+				"spawn-wrap": {
+					"version": "1.4.2",
+					"bundled": true,
+					"requires": {
+						"foreground-child": "1.5.6",
+						"mkdirp": "0.5.1",
+						"os-homedir": "1.0.2",
+						"rimraf": "2.6.2",
+						"signal-exit": "3.0.2",
+						"which": "1.3.0"
+					}
+				},
+				"spdx-correct": {
+					"version": "3.0.0",
+					"bundled": true,
+					"requires": {
+						"spdx-expression-parse": "3.0.0",
+						"spdx-license-ids": "3.0.0"
+					}
+				},
+				"spdx-exceptions": {
+					"version": "2.1.0",
+					"bundled": true
+				},
+				"spdx-expression-parse": {
+					"version": "3.0.0",
+					"bundled": true,
+					"requires": {
+						"spdx-exceptions": "2.1.0",
+						"spdx-license-ids": "3.0.0"
+					}
+				},
+				"spdx-license-ids": {
+					"version": "3.0.0",
+					"bundled": true
+				},
+				"split-string": {
+					"version": "3.1.0",
+					"bundled": true,
+					"requires": {
+						"extend-shallow": "3.0.2"
+					}
+				},
+				"static-extend": {
+					"version": "0.1.2",
+					"bundled": true,
+					"requires": {
+						"define-property": "0.2.5",
+						"object-copy": "0.1.0"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "0.2.5",
+							"bundled": true,
+							"requires": {
+								"is-descriptor": "0.1.6"
+							}
+						},
+						"is-accessor-descriptor": {
+							"version": "0.1.6",
+							"bundled": true,
+							"requires": {
+								"kind-of": "3.2.2"
+							},
+							"dependencies": {
+								"kind-of": {
+									"version": "3.2.2",
+									"bundled": true,
+									"requires": {
+										"is-buffer": "1.1.6"
+									}
+								}
+							}
+						},
+						"is-data-descriptor": {
+							"version": "0.1.4",
+							"bundled": true,
+							"requires": {
+								"kind-of": "3.2.2"
+							},
+							"dependencies": {
+								"kind-of": {
+									"version": "3.2.2",
+									"bundled": true,
+									"requires": {
+										"is-buffer": "1.1.6"
+									}
+								}
+							}
+						},
+						"is-descriptor": {
+							"version": "0.1.6",
+							"bundled": true,
+							"requires": {
+								"is-accessor-descriptor": "0.1.6",
+								"is-data-descriptor": "0.1.4",
+								"kind-of": "5.1.0"
+							}
+						},
+						"kind-of": {
+							"version": "5.1.0",
+							"bundled": true
+						}
+					}
+				},
+				"string-width": {
+					"version": "2.1.1",
+					"bundled": true,
+					"requires": {
+						"is-fullwidth-code-point": "2.0.0",
+						"strip-ansi": "4.0.0"
+					},
+					"dependencies": {
+						"ansi-regex": {
+							"version": "3.0.0",
+							"bundled": true
+						},
+						"strip-ansi": {
+							"version": "4.0.0",
+							"bundled": true,
+							"requires": {
+								"ansi-regex": "3.0.0"
+							}
+						}
+					}
+				},
+				"strip-ansi": {
+					"version": "3.0.1",
+					"bundled": true,
+					"requires": {
+						"ansi-regex": "2.1.1"
+					}
+				},
+				"strip-bom": {
+					"version": "2.0.0",
+					"bundled": true,
+					"requires": {
+						"is-utf8": "0.2.1"
+					}
+				},
+				"strip-eof": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"supports-color": {
+					"version": "2.0.0",
+					"bundled": true
+				},
+				"test-exclude": {
+					"version": "4.2.1",
+					"bundled": true,
+					"requires": {
+						"arrify": "1.0.1",
+						"micromatch": "3.1.9",
+						"object-assign": "4.1.1",
+						"read-pkg-up": "1.0.1",
+						"require-main-filename": "1.0.1"
+					},
+					"dependencies": {
+						"arr-diff": {
+							"version": "4.0.0",
+							"bundled": true
+						},
+						"array-unique": {
+							"version": "0.3.2",
+							"bundled": true
+						},
+						"braces": {
+							"version": "2.3.1",
+							"bundled": true,
+							"requires": {
+								"arr-flatten": "1.1.0",
+								"array-unique": "0.3.2",
+								"define-property": "1.0.0",
+								"extend-shallow": "2.0.1",
+								"fill-range": "4.0.0",
+								"isobject": "3.0.1",
+								"kind-of": "6.0.2",
+								"repeat-element": "1.1.2",
+								"snapdragon": "0.8.2",
+								"snapdragon-node": "2.1.1",
+								"split-string": "3.1.0",
+								"to-regex": "3.0.2"
+							},
+							"dependencies": {
+								"define-property": {
+									"version": "1.0.0",
+									"bundled": true,
+									"requires": {
+										"is-descriptor": "1.0.2"
+									}
+								},
+								"extend-shallow": {
+									"version": "2.0.1",
+									"bundled": true,
+									"requires": {
+										"is-extendable": "0.1.1"
+									}
+								}
+							}
+						},
+						"expand-brackets": {
+							"version": "2.1.4",
+							"bundled": true,
+							"requires": {
+								"debug": "2.6.9",
+								"define-property": "0.2.5",
+								"extend-shallow": "2.0.1",
+								"posix-character-classes": "0.1.1",
+								"regex-not": "1.0.2",
+								"snapdragon": "0.8.2",
+								"to-regex": "3.0.2"
+							},
+							"dependencies": {
+								"define-property": {
+									"version": "0.2.5",
+									"bundled": true,
+									"requires": {
+										"is-descriptor": "0.1.6"
+									}
+								},
+								"extend-shallow": {
+									"version": "2.0.1",
+									"bundled": true,
+									"requires": {
+										"is-extendable": "0.1.1"
+									}
+								},
+								"is-descriptor": {
+									"version": "0.1.6",
+									"bundled": true,
+									"requires": {
+										"is-accessor-descriptor": "0.1.6",
+										"is-data-descriptor": "0.1.4",
+										"kind-of": "5.1.0"
+									}
+								},
+								"kind-of": {
+									"version": "5.1.0",
+									"bundled": true
+								}
+							}
+						},
+						"extglob": {
+							"version": "2.0.4",
+							"bundled": true,
+							"requires": {
+								"array-unique": "0.3.2",
+								"define-property": "1.0.0",
+								"expand-brackets": "2.1.4",
+								"extend-shallow": "2.0.1",
+								"fragment-cache": "0.2.1",
+								"regex-not": "1.0.2",
+								"snapdragon": "0.8.2",
+								"to-regex": "3.0.2"
+							},
+							"dependencies": {
+								"define-property": {
+									"version": "1.0.0",
+									"bundled": true,
+									"requires": {
+										"is-descriptor": "1.0.2"
+									}
+								},
+								"extend-shallow": {
+									"version": "2.0.1",
+									"bundled": true,
+									"requires": {
+										"is-extendable": "0.1.1"
+									}
+								}
+							}
+						},
+						"fill-range": {
+							"version": "4.0.0",
+							"bundled": true,
+							"requires": {
+								"extend-shallow": "2.0.1",
+								"is-number": "3.0.0",
+								"repeat-string": "1.6.1",
+								"to-regex-range": "2.1.1"
+							},
+							"dependencies": {
+								"extend-shallow": {
+									"version": "2.0.1",
+									"bundled": true,
+									"requires": {
+										"is-extendable": "0.1.1"
+									}
+								}
+							}
+						},
+						"is-accessor-descriptor": {
+							"version": "0.1.6",
+							"bundled": true,
+							"requires": {
+								"kind-of": "3.2.2"
+							},
+							"dependencies": {
+								"kind-of": {
+									"version": "3.2.2",
+									"bundled": true,
+									"requires": {
+										"is-buffer": "1.1.6"
+									}
+								}
+							}
+						},
+						"is-data-descriptor": {
+							"version": "0.1.4",
+							"bundled": true,
+							"requires": {
+								"kind-of": "3.2.2"
+							},
+							"dependencies": {
+								"kind-of": {
+									"version": "3.2.2",
+									"bundled": true,
+									"requires": {
+										"is-buffer": "1.1.6"
+									}
+								}
+							}
+						},
+						"is-number": {
+							"version": "3.0.0",
+							"bundled": true,
+							"requires": {
+								"kind-of": "3.2.2"
+							},
+							"dependencies": {
+								"kind-of": {
+									"version": "3.2.2",
+									"bundled": true,
+									"requires": {
+										"is-buffer": "1.1.6"
+									}
+								}
+							}
+						},
+						"isobject": {
+							"version": "3.0.1",
+							"bundled": true
+						},
+						"kind-of": {
+							"version": "6.0.2",
+							"bundled": true
+						},
+						"micromatch": {
+							"version": "3.1.9",
+							"bundled": true,
+							"requires": {
+								"arr-diff": "4.0.0",
+								"array-unique": "0.3.2",
+								"braces": "2.3.1",
+								"define-property": "2.0.2",
+								"extend-shallow": "3.0.2",
+								"extglob": "2.0.4",
+								"fragment-cache": "0.2.1",
+								"kind-of": "6.0.2",
+								"nanomatch": "1.2.9",
+								"object.pick": "1.3.0",
+								"regex-not": "1.0.2",
+								"snapdragon": "0.8.2",
+								"to-regex": "3.0.2"
+							}
+						}
+					}
+				},
+				"to-fast-properties": {
+					"version": "1.0.3",
+					"bundled": true
+				},
+				"to-object-path": {
+					"version": "0.3.0",
+					"bundled": true,
+					"requires": {
+						"kind-of": "3.2.2"
+					}
+				},
+				"to-regex": {
+					"version": "3.0.2",
+					"bundled": true,
+					"requires": {
+						"define-property": "2.0.2",
+						"extend-shallow": "3.0.2",
+						"regex-not": "1.0.2",
+						"safe-regex": "1.1.0"
+					}
+				},
+				"to-regex-range": {
+					"version": "2.1.1",
+					"bundled": true,
+					"requires": {
+						"is-number": "3.0.0",
+						"repeat-string": "1.6.1"
+					},
+					"dependencies": {
+						"is-number": {
+							"version": "3.0.0",
+							"bundled": true,
+							"requires": {
+								"kind-of": "3.2.2"
+							}
+						}
+					}
+				},
+				"trim-right": {
+					"version": "1.0.1",
+					"bundled": true
+				},
+				"uglify-js": {
+					"version": "2.8.29",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"source-map": "0.5.7",
+						"uglify-to-browserify": "1.0.2",
+						"yargs": "3.10.0"
+					},
+					"dependencies": {
+						"yargs": {
+							"version": "3.10.0",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"camelcase": "1.2.1",
+								"cliui": "2.1.0",
+								"decamelize": "1.2.0",
+								"window-size": "0.1.0"
+							}
+						}
+					}
+				},
+				"uglify-to-browserify": {
+					"version": "1.0.2",
+					"bundled": true,
+					"optional": true
+				},
+				"union-value": {
+					"version": "1.0.0",
+					"bundled": true,
+					"requires": {
+						"arr-union": "3.1.0",
+						"get-value": "2.0.6",
+						"is-extendable": "0.1.1",
+						"set-value": "0.4.3"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"bundled": true,
+							"requires": {
+								"is-extendable": "0.1.1"
+							}
+						},
+						"set-value": {
+							"version": "0.4.3",
+							"bundled": true,
+							"requires": {
+								"extend-shallow": "2.0.1",
+								"is-extendable": "0.1.1",
+								"is-plain-object": "2.0.4",
+								"to-object-path": "0.3.0"
+							}
+						}
+					}
+				},
+				"unset-value": {
+					"version": "1.0.0",
+					"bundled": true,
+					"requires": {
+						"has-value": "0.3.1",
+						"isobject": "3.0.1"
+					},
+					"dependencies": {
+						"has-value": {
+							"version": "0.3.1",
+							"bundled": true,
+							"requires": {
+								"get-value": "2.0.6",
+								"has-values": "0.1.4",
+								"isobject": "2.1.0"
+							},
+							"dependencies": {
+								"isobject": {
+									"version": "2.1.0",
+									"bundled": true,
+									"requires": {
+										"isarray": "1.0.0"
+									}
+								}
+							}
+						},
+						"has-values": {
+							"version": "0.1.4",
+							"bundled": true
+						},
+						"isobject": {
+							"version": "3.0.1",
+							"bundled": true
+						}
+					}
+				},
+				"urix": {
+					"version": "0.1.0",
+					"bundled": true
+				},
+				"use": {
+					"version": "3.1.0",
+					"bundled": true,
+					"requires": {
+						"kind-of": "6.0.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "6.0.2",
+							"bundled": true
+						}
+					}
+				},
+				"validate-npm-package-license": {
+					"version": "3.0.3",
+					"bundled": true,
+					"requires": {
+						"spdx-correct": "3.0.0",
+						"spdx-expression-parse": "3.0.0"
+					}
+				},
+				"which": {
+					"version": "1.3.0",
+					"bundled": true,
+					"requires": {
+						"isexe": "2.0.0"
+					}
+				},
+				"which-module": {
+					"version": "2.0.0",
+					"bundled": true
+				},
+				"window-size": {
+					"version": "0.1.0",
+					"bundled": true,
+					"optional": true
+				},
+				"wordwrap": {
+					"version": "0.0.3",
+					"bundled": true
+				},
+				"wrap-ansi": {
+					"version": "2.1.0",
+					"bundled": true,
+					"requires": {
+						"string-width": "1.0.2",
+						"strip-ansi": "3.0.1"
+					},
+					"dependencies": {
+						"is-fullwidth-code-point": {
+							"version": "1.0.0",
+							"bundled": true,
+							"requires": {
+								"number-is-nan": "1.0.1"
+							}
+						},
+						"string-width": {
+							"version": "1.0.2",
+							"bundled": true,
+							"requires": {
+								"code-point-at": "1.1.0",
+								"is-fullwidth-code-point": "1.0.0",
+								"strip-ansi": "3.0.1"
+							}
+						}
+					}
+				},
+				"wrappy": {
+					"version": "1.0.2",
+					"bundled": true
+				},
+				"write-file-atomic": {
+					"version": "1.3.4",
+					"bundled": true,
+					"requires": {
+						"graceful-fs": "4.1.11",
+						"imurmurhash": "0.1.4",
+						"slide": "1.1.6"
+					}
+				},
+				"y18n": {
+					"version": "3.2.1",
+					"bundled": true
+				},
+				"yallist": {
+					"version": "2.1.2",
+					"bundled": true
+				},
+				"yargs": {
+					"version": "11.1.0",
+					"bundled": true,
+					"requires": {
+						"cliui": "4.0.0",
+						"decamelize": "1.2.0",
+						"find-up": "2.1.0",
+						"get-caller-file": "1.0.2",
+						"os-locale": "2.1.0",
+						"require-directory": "2.1.1",
+						"require-main-filename": "1.0.1",
+						"set-blocking": "2.0.0",
+						"string-width": "2.1.1",
+						"which-module": "2.0.0",
+						"y18n": "3.2.1",
+						"yargs-parser": "9.0.2"
+					},
+					"dependencies": {
+						"ansi-regex": {
+							"version": "3.0.0",
+							"bundled": true
+						},
+						"camelcase": {
+							"version": "4.1.0",
+							"bundled": true
+						},
+						"cliui": {
+							"version": "4.0.0",
+							"bundled": true,
+							"requires": {
+								"string-width": "2.1.1",
+								"strip-ansi": "4.0.0",
+								"wrap-ansi": "2.1.0"
+							}
+						},
+						"strip-ansi": {
+							"version": "4.0.0",
+							"bundled": true,
+							"requires": {
+								"ansi-regex": "3.0.0"
+							}
+						},
+						"yargs-parser": {
+							"version": "9.0.2",
+							"bundled": true,
+							"requires": {
+								"camelcase": "4.1.0"
+							}
+						}
+					}
+				},
+				"yargs-parser": {
+					"version": "8.1.0",
+					"bundled": true,
+					"requires": {
+						"camelcase": "4.1.0"
+					},
+					"dependencies": {
+						"camelcase": {
+							"version": "4.1.0",
+							"bundled": true
+						}
+					}
+				}
+			}
+		},
+		"oauth-sign": {
+			"version": "0.8.2",
+			"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+			"integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
+			"dev": true
+		},
+		"object-assign": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+			"dev": true
+		},
+		"once": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+			"requires": {
+				"wrappy": "1.0.2"
+			}
+		},
+		"onetime": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+			"integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+			"dev": true,
+			"requires": {
+				"mimic-fn": "1.2.0"
+			}
+		},
+		"optimist": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+			"integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+			"dev": true,
+			"requires": {
+				"minimist": "0.0.8",
+				"wordwrap": "0.0.3"
+			}
+		},
+		"optionator": {
+			"version": "0.8.2",
+			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+			"integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+			"dev": true,
+			"requires": {
+				"deep-is": "0.1.3",
+				"fast-levenshtein": "2.0.6",
+				"levn": "0.3.0",
+				"prelude-ls": "1.1.2",
+				"type-check": "0.3.2",
+				"wordwrap": "1.0.0"
+			},
+			"dependencies": {
+				"wordwrap": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+					"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+					"dev": true
+				}
+			}
+		},
+		"os-tmpdir": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+			"dev": true
+		},
+		"p-finally": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+			"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+			"dev": true
+		},
+		"package-json": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
+			"integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
+			"dev": true,
+			"requires": {
+				"got": "6.7.1",
+				"registry-auth-token": "3.3.2",
+				"registry-url": "3.1.0",
+				"semver": "5.5.0"
+			}
+		},
+		"parse-cmd-args": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/parse-cmd-args/-/parse-cmd-args-2.0.0.tgz",
+			"integrity": "sha1-KtbQ/UhdeWMs1AbIPU2HfXk6k1U=",
+			"dev": true
+		},
+		"path-is-absolute": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+		},
+		"path-is-inside": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+			"integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+			"dev": true
+		},
+		"path-key": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+			"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+			"dev": true
+		},
+		"pend": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+			"integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA="
+		},
+		"performance-now": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+			"dev": true
+		},
+		"pify": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+			"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+			"dev": true
+		},
+		"pinkie": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+			"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+			"dev": true
+		},
+		"pinkie-promise": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+			"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+			"dev": true,
+			"requires": {
+				"pinkie": "2.0.4"
+			}
+		},
+		"pluralize": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
+			"integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
+			"dev": true
+		},
+		"prelude-ls": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+			"dev": true
+		},
+		"prepend-http": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+			"integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
+			"dev": true
+		},
+		"process-nextick-args": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+			"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+		},
+		"progress": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
+			"integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8="
+		},
+		"proxy-from-env": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.0.0.tgz",
+			"integrity": "sha1-M8UDmPcOp+uW0h97gXYwpVeRx+4="
+		},
+		"pseudomap": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+			"dev": true
+		},
+		"punycode": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+			"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+			"dev": true
+		},
+		"puppeteer": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-1.0.0.tgz",
+			"integrity": "sha512-e00NMdUL32YhBcua9OkVXHgyDEMBWJhDXkYNv0pyKRU1Z1OrsRm5zCpppAdxAsBI+/MJBspFNfOUZuZ24qPGMQ==",
+			"requires": {
+				"debug": "2.6.9",
+				"extract-zip": "1.6.6",
+				"https-proxy-agent": "2.2.1",
+				"mime": "1.6.0",
+				"progress": "2.0.0",
+				"proxy-from-env": "1.0.0",
+				"rimraf": "2.6.2",
+				"ws": "3.3.3"
+			}
+		},
+		"qs": {
+			"version": "6.5.1",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+			"integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
+			"dev": true
+		},
+		"rc": {
+			"version": "1.2.6",
+			"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.6.tgz",
+			"integrity": "sha1-6xiYnG1PTxYsOZ953dKfODVWgJI=",
+			"dev": true,
+			"requires": {
+				"deep-extend": "0.4.2",
+				"ini": "1.3.5",
+				"minimist": "1.2.0",
+				"strip-json-comments": "2.0.1"
+			},
+			"dependencies": {
+				"minimist": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+					"dev": true
+				}
+			}
+		},
+		"readable-stream": {
+			"version": "2.3.5",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.5.tgz",
+			"integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
+			"requires": {
+				"core-util-is": "1.0.2",
+				"inherits": "2.0.3",
+				"isarray": "1.0.0",
+				"process-nextick-args": "2.0.0",
+				"safe-buffer": "5.1.1",
+				"string_decoder": "1.0.3",
+				"util-deprecate": "1.0.2"
+			}
+		},
+		"regexpp": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-1.1.0.tgz",
+			"integrity": "sha512-LOPw8FpgdQF9etWMaAfG/WRthIdXJGYp4mJ2Jgn/2lpkbod9jPn0t9UqN7AxBOKNfzRbYyVfgc7Vk4t/MpnXgw==",
+			"dev": true
+		},
+		"registry-auth-token": {
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.2.tgz",
+			"integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
+			"dev": true,
+			"requires": {
+				"rc": "1.2.6",
+				"safe-buffer": "5.1.1"
+			}
+		},
+		"registry-url": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
+			"integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
+			"dev": true,
+			"requires": {
+				"rc": "1.2.6"
+			}
+		},
+		"repeat-string": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+			"dev": true
+		},
+		"request": {
+			"version": "2.85.0",
+			"resolved": "https://registry.npmjs.org/request/-/request-2.85.0.tgz",
+			"integrity": "sha512-8H7Ehijd4js+s6wuVPLjwORxD4zeuyjYugprdOXlPSqaApmL/QOy+EB/beICHVCHkGMKNh5rvihb5ov+IDw4mg==",
+			"dev": true,
+			"requires": {
+				"aws-sign2": "0.7.0",
+				"aws4": "1.6.0",
+				"caseless": "0.12.0",
+				"combined-stream": "1.0.6",
+				"extend": "3.0.1",
+				"forever-agent": "0.6.1",
+				"form-data": "2.3.2",
+				"har-validator": "5.0.3",
+				"hawk": "6.0.2",
+				"http-signature": "1.2.0",
+				"is-typedarray": "1.0.0",
+				"isstream": "0.1.2",
+				"json-stringify-safe": "5.0.1",
+				"mime-types": "2.1.18",
+				"oauth-sign": "0.8.2",
+				"performance-now": "2.1.0",
+				"qs": "6.5.1",
+				"safe-buffer": "5.1.1",
+				"stringstream": "0.0.5",
+				"tough-cookie": "2.3.4",
+				"tunnel-agent": "0.6.0",
+				"uuid": "3.2.1"
+			}
+		},
+		"require-uncached": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+			"integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
+			"dev": true,
+			"requires": {
+				"caller-path": "0.1.0",
+				"resolve-from": "1.0.1"
+			}
+		},
+		"resolve-from": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
+			"integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
+			"dev": true
+		},
+		"restore-cursor": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+			"integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+			"dev": true,
+			"requires": {
+				"onetime": "2.0.1",
+				"signal-exit": "3.0.2"
+			}
+		},
+		"right-align": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+			"integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"align-text": "0.1.4"
+			}
+		},
+		"rimraf": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+			"integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+			"requires": {
+				"glob": "7.1.2"
+			}
+		},
+		"run-async": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
+			"integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+			"dev": true,
+			"requires": {
+				"is-promise": "2.1.0"
+			}
+		},
+		"rx-lite": {
+			"version": "4.0.8",
+			"resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
+			"integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
+			"dev": true
+		},
+		"rx-lite-aggregates": {
+			"version": "4.0.8",
+			"resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
+			"integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
+			"dev": true,
+			"requires": {
+				"rx-lite": "4.0.8"
+			}
+		},
+		"safe-buffer": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+			"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+		},
+		"semver": {
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+			"integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+			"dev": true
+		},
+		"semver-diff": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
+			"integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
+			"dev": true,
+			"requires": {
+				"semver": "5.5.0"
+			}
+		},
+		"shebang-command": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+			"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+			"dev": true,
+			"requires": {
+				"shebang-regex": "1.0.0"
+			}
+		},
+		"shebang-regex": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+			"dev": true
+		},
+		"signal-exit": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+			"dev": true
+		},
+		"slice-ansi": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
+			"integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
+			"dev": true,
+			"requires": {
+				"is-fullwidth-code-point": "2.0.0"
+			}
+		},
+		"sntp": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
+			"integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
+			"dev": true,
+			"requires": {
+				"hoek": "4.2.1"
+			}
+		},
+		"source-map": {
+			"version": "0.4.4",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+			"integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+			"dev": true,
+			"requires": {
+				"amdefine": "1.0.1"
+			}
+		},
+		"sprintf-js": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+			"dev": true
+		},
+		"sshpk": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.1.tgz",
+			"integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
+			"dev": true,
+			"requires": {
+				"asn1": "0.2.3",
+				"assert-plus": "1.0.0",
+				"bcrypt-pbkdf": "1.0.1",
+				"dashdash": "1.14.1",
+				"ecc-jsbn": "0.1.1",
+				"getpass": "0.1.7",
+				"jsbn": "0.1.1",
+				"tweetnacl": "0.14.5"
+			}
+		},
+		"string-width": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+			"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+			"dev": true,
+			"requires": {
+				"is-fullwidth-code-point": "2.0.0",
+				"strip-ansi": "4.0.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"dev": true
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "3.0.0"
+					}
+				}
+			}
+		},
+		"string_decoder": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+			"integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+			"requires": {
+				"safe-buffer": "5.1.1"
+			}
+		},
+		"stringstream": {
+			"version": "0.0.5",
+			"resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+			"integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
+			"dev": true
+		},
+		"strip-ansi": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+			"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+			"dev": true,
+			"requires": {
+				"ansi-regex": "2.1.1"
+			}
+		},
+		"strip-eof": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+			"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+			"dev": true
+		},
+		"strip-json-comments": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+			"dev": true
+		},
+		"supports-color": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+			"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+			"dev": true
+		},
+		"table": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
+			"integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
+			"dev": true,
+			"requires": {
+				"ajv": "5.5.2",
+				"ajv-keywords": "2.1.1",
+				"chalk": "2.3.2",
+				"lodash": "4.17.5",
+				"slice-ansi": "1.0.0",
+				"string-width": "2.1.1"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
+					"requires": {
+						"color-convert": "1.9.1"
+					}
+				},
+				"chalk": {
+					"version": "2.3.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
+					"integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "3.2.1",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.3.0"
+					}
+				},
+				"lodash": {
+					"version": "4.17.5",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
+					"integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "5.3.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
+					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+					"dev": true,
+					"requires": {
+						"has-flag": "3.0.0"
+					}
+				}
+			}
+		},
+		"term-size": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
+			"integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
+			"dev": true,
+			"requires": {
+				"execa": "0.7.0"
+			}
+		},
+		"text-table": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+			"integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+			"dev": true
+		},
+		"through": {
+			"version": "2.3.8",
+			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+			"dev": true
+		},
+		"timed-out": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
+			"integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
+			"dev": true
+		},
+		"tmp": {
+			"version": "0.0.33",
+			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+			"integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+			"dev": true,
+			"requires": {
+				"os-tmpdir": "1.0.2"
+			}
+		},
+		"tough-cookie": {
+			"version": "2.3.4",
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
+			"integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
+			"dev": true,
+			"requires": {
+				"punycode": "1.4.1"
+			}
+		},
+		"tunnel-agent": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+			"dev": true,
+			"requires": {
+				"safe-buffer": "5.1.1"
+			}
+		},
+		"tweetnacl": {
+			"version": "0.14.5",
+			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+			"dev": true,
+			"optional": true
+		},
+		"type-check": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+			"integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+			"dev": true,
+			"requires": {
+				"prelude-ls": "1.1.2"
+			}
+		},
+		"typedarray": {
+			"version": "0.0.6",
+			"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+		},
+		"uc.micro": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.5.tgz",
+			"integrity": "sha512-JoLI4g5zv5qNyT09f4YAvEZIIV1oOjqnewYg5D38dkQljIzpPT296dbIGvKro3digYI1bkb7W6EP1y4uDlmzLg==",
+			"dev": true
+		},
+		"uglify-js": {
+			"version": "2.8.29",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
+			"integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"source-map": "0.5.7",
+				"uglify-to-browserify": "1.0.2",
+				"yargs": "3.10.0"
+			},
+			"dependencies": {
+				"source-map": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true,
+					"optional": true
+				}
+			}
+		},
+		"uglify-to-browserify": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+			"integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
+			"dev": true,
+			"optional": true
+		},
+		"ultron": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
+			"integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og=="
+		},
+		"unique-string": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
+			"integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
+			"dev": true,
+			"requires": {
+				"crypto-random-string": "1.0.0"
+			}
+		},
+		"unzip-response": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz",
+			"integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c=",
+			"dev": true
+		},
+		"update-notifier": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.1.0.tgz",
+			"integrity": "sha1-7AweU1NrdmR6JLd8uDlm2TFRI9k=",
+			"dev": true,
+			"requires": {
+				"boxen": "1.3.0",
+				"chalk": "1.1.3",
+				"configstore": "3.1.2",
+				"is-npm": "1.0.0",
+				"latest-version": "3.1.0",
+				"lazy-req": "2.0.0",
+				"semver-diff": "2.1.0",
+				"xdg-basedir": "3.0.0"
+			}
+		},
+		"url-parse-lax": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
+			"integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
+			"dev": true,
+			"requires": {
+				"prepend-http": "1.0.4"
+			}
+		},
+		"util-deprecate": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+		},
+		"uuid": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
+			"integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA==",
+			"dev": true
+		},
+		"verror": {
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+			"dev": true,
+			"requires": {
+				"assert-plus": "1.0.0",
+				"core-util-is": "1.0.2",
+				"extsprintf": "1.3.0"
+			}
+		},
+		"which": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
+			"integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+			"dev": true,
+			"requires": {
+				"isexe": "2.0.0"
+			}
+		},
+		"widest-line": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.0.tgz",
+			"integrity": "sha1-AUKk6KJD+IgsAjOqDgKBqnYVInM=",
+			"dev": true,
+			"requires": {
+				"string-width": "2.1.1"
+			}
+		},
+		"window-size": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+			"integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
+			"dev": true,
+			"optional": true
+		},
+		"wordwrap": {
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+			"integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+			"dev": true
+		},
+		"wrappy": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+		},
+		"write": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
+			"integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+			"dev": true,
+			"requires": {
+				"mkdirp": "0.5.1"
+			},
+			"dependencies": {
+				"mkdirp": {
+					"version": "0.5.1",
+					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+					"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+					"dev": true,
+					"requires": {
+						"minimist": "0.0.8"
+					}
+				}
+			}
+		},
+		"write-file-atomic": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
+			"integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
+			"dev": true,
+			"requires": {
+				"graceful-fs": "4.1.11",
+				"imurmurhash": "0.1.4",
+				"signal-exit": "3.0.2"
+			}
+		},
+		"ws": {
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
+			"integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
+			"requires": {
+				"async-limiter": "1.0.0",
+				"safe-buffer": "5.1.1",
+				"ultron": "1.1.1"
+			}
+		},
+		"xdg-basedir": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
+			"integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
+			"dev": true
+		},
+		"yallist": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+			"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+			"dev": true
+		},
+		"yargs": {
+			"version": "3.10.0",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+			"integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"camelcase": "1.2.1",
+				"cliui": "2.1.0",
+				"decamelize": "1.2.0",
+				"window-size": "0.1.0"
+			}
+		},
+		"yauzl": {
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
+			"integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
+			"requires": {
+				"fd-slicer": "1.0.1"
+			}
+		}
+	}
+}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
 	"dependencies": {
 		"jasmine": "^2.9.0",
 		"nyc": "^11.4.1",
-		"puppeteer": "^1.0.0"
+		"puppeteer": "^1.3.0"
 	},
 	"repository": {
 		"type": "git",

--- a/yarn.lock
+++ b/yarn.lock
@@ -253,8 +253,8 @@ boxen@^1.0.0:
     widest-line "^2.0.0"
 
 brace-expansion@^1.1.7:
-  version "1.1.8"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.8.tgz#c07b211c7c952ec1f8efd51a77ef0d1d3990a292"
+  version "1.1.11"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
@@ -1073,8 +1073,8 @@ http-signature@~1.2.0:
     sshpk "^1.7.0"
 
 https-proxy-agent@^2.1.0:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-2.1.1.tgz#a7ce4382a1ba8266ee848578778122d491260fd9"
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz#51552970fa04d723e04c56d04178c3f92592bbc0"
   dependencies:
     agent-base "^4.1.0"
     debug "^3.1.0"
@@ -1876,9 +1876,9 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
-process-nextick-args@~1.0.6:
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-1.0.7.tgz#150e20b756590ad3f91093f25a4f2ad8bff30ba3"
+process-nextick-args@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.0.tgz#a37d732f4271b4ab1ad070d35508e8290788ffaa"
 
 progress@^2.0.0:
   version "2.0.0"
@@ -1896,9 +1896,9 @@ punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
 
-puppeteer@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-1.0.0.tgz#20f3bb6ad6c6778b4d1fb750e808a29fec0a88a4"
+puppeteer@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-1.3.0.tgz#f571c5f27153ca164a8188e6328ce2e4946878f3"
   dependencies:
     debug "^2.6.8"
     extract-zip "^1.6.5"
@@ -1945,15 +1945,15 @@ read-pkg@^1.0.0:
     path-type "^1.0.0"
 
 readable-stream@^2.2.2:
-  version "2.3.3"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.3.tgz#368f2512d79f9d46fdfc71349ae7878bbc1eb95c"
+  version "2.3.6"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
   dependencies:
     core-util-is "~1.0.0"
     inherits "~2.0.3"
     isarray "~1.0.0"
-    process-nextick-args "~1.0.6"
+    process-nextick-args "~2.0.0"
     safe-buffer "~5.1.1"
-    string_decoder "~1.0.3"
+    string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
 regenerator-runtime@^0.11.0:
@@ -2202,9 +2202,9 @@ string-width@^2.0.0, string-width@^2.1.0, string-width@^2.1.1:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
 
-string_decoder@~1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.0.3.tgz#0fc67d7c141825de94282dd536bec6b9bce860ab"
+string_decoder@~1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
   dependencies:
     safe-buffer "~5.1.0"
 


### PR DESCRIPTION
Ref: #27 

Puppeteer has moved the Target class to its own file, so we must import
this class from its own file. Otherwise our override doesn't work
anymore.

Also added the possibility to add startup aguments to the nwjs launch
url.

Upgraded puppeteer to v1.3.0